### PR TITLE
Rename to percore.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# This is the list of percpu's significant contributors.
+# This is the list of percore's significant contributors.
 #
 # This does not necessarily list everyone who has contributed code,
 # especially since many employees of one corporation may be contributing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "percpu"
+name = "percore"
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "percpu"
+name = "percore"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-description = "Safe per-CPU mutable state on no_std platforms through exception masking."
+description = "Safe per-CPU core mutable state on no_std platforms through exception masking."
 authors = ["Andrew Walbran <qwandor@google.com>"]
-repository = "https://github.com/google/percpu"
+repository = "https://github.com/google/percore"
 keywords = ["aarch64", "exceptions"]
 categories = ["embedded", "no-std", "rust-patterns"]
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# percpu
+# percore
 
-[![crates.io page](https://img.shields.io/crates/v/percpu.svg)](https://crates.io/crates/percpu)
-[![docs.rs page](https://docs.rs/percpu/badge.svg)](https://docs.rs/percpu)
+[![crates.io page](https://img.shields.io/crates/v/percore.svg)](https://crates.io/crates/percore)
+[![docs.rs page](https://docs.rs/percore/badge.svg)](https://docs.rs/percore)
 
-Safe per-CPU mutable state on no_std platforms through exception masking.
+Safe per-CPU core mutable state on no_std platforms through exception masking.
 
-This crate provides two main wrapper types: `PerCpu` to provide an instance of a value per
+This crate provides two main wrapper types: `PerCore` to provide an instance of a value per
 CPU core, where each core can access only its instance, and `ExceptionLock` to guard a value
 so that it can only be accessed while exceptions are masked. These may be combined with
-`RefCell` to provide safe per-CPU mutable state.
+`RefCell` to provide safe per-core mutable state.
 
 `ExceptionLock` may also be combined with a spinlock-based mutex (such as one provided by the
 [`spin`](https://crates.io/crates/spin) crate) to avoid deadlocks when accessing global mutable
@@ -18,7 +18,7 @@ state from exception handlers.
 
 ```rust
 use core::cell::RefCell;
-use percpu::{exception_free, Cores, ExceptionLock, PerCpu};
+use percore::{exception_free, Cores, ExceptionLock, PerCore};
 
 /// The total number of CPU cores in the target system.
 const CORE_COUNT: usize = 2;
@@ -31,22 +31,22 @@ unsafe impl Cores for CoresImpl {
     }
 }
 
-struct CpuState {
-    // Your per-CPU mutable state goes here...
+struct CoreState {
+    // Your per-core mutable state goes here...
     foo: u32,
 }
 
-const EMPTY_CPU_STATE: ExceptionLock<RefCell<CpuState>> =
-    ExceptionLock::new(RefCell::new(CpuState { foo: 0 }));
-static CPU_STATE: PerCpu<ExceptionLock<RefCell<CpuState>>, CoresImpl, CORE_COUNT> =
-    PerCpu::new([EMPTY_CPU_STATE; CORE_COUNT]);
+const EMPTY_CORE_STATE: ExceptionLock<RefCell<CoreState>> =
+    ExceptionLock::new(RefCell::new(CoreState { foo: 0 }));
+static CORE_STATE: PerCore<ExceptionLock<RefCell<CoreState>>, CoresImpl, CORE_COUNT> =
+    PerCore::new([EMPTY_CORE_STATE; CORE_COUNT]);
 
 fn main() {
     // Mask exceptions while accessing mutable state.
     exception_free(|token| {
-        // `token` proves that interrupts are masked, so we can safely access per-CPU mutable
+        // `token` proves that interrupts are masked, so we can safely access per-core mutable
         // state.
-        CPU_STATE.get().borrow_mut(token).foo = 42;
+        CORE_STATE.get().borrow_mut(token).foo = 42;
     });
 }
 ```

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 The percpu Authors.
+// Copyright 2024 The percore Authors.
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 

--- a/src/exceptions/aarch64.rs
+++ b/src/exceptions/aarch64.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 The percpu Authors.
+// Copyright 2024 The percore Authors.
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 The percpu Authors.
+// Copyright 2024 The percore Authors.
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
@@ -6,7 +6,7 @@ use crate::ExceptionFree;
 use core::cell::{RefCell, RefMut};
 
 /// Allows access to the given value only while exceptions are masked, allowing it to be shared
-/// between exception contexts on a given CPU.
+/// between exception contexts on a given core.
 pub struct ExceptionLock<T> {
     value: T,
 }


### PR DESCRIPTION
Somebody else published a crate called `percpu` in the meantime.