### PR TITLE
Update lock.rs

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -26,12 +26,17 @@ impl<T> ExceptionLock<T> {
     /// Creates a new `ExceptionLock` containing the given value.
     pub const fn new(value: T) -> Self {
         Self { value }
-    }
+    }   
 
     /// Gets a reference to the contents of the cell, given a token proving that exceptions are
     /// currently masked.
     pub fn borrow<'cs>(&'cs self, _: ExceptionFree<'cs>) -> &'cs T {
         &self.value
+    }
+
+    /// Consumes the `ExceptionLock`, returning the wrapped value.
+    pub fn into_inner(self) -> T {
+        self.value
     }
 }
 


### PR DESCRIPTION
tries to consume and return a value that might have a non-trivial destructor. Constant functions can't run destructors the compiler prevents this because it can't guarantee the operation is compiletime safe