### PR TITLE
Add percore attribute macro feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- Added `percore-derive` and `derive` feature.
+
 ## 0.2.4
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,8 +134,17 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 name = "percore"
 version = "0.2.4"
 dependencies = [
+ "percore-derive",
  "spin 0.12.2",
  "zerocopy",
+]
+
+[[package]]
+name = "percore-derive"
+version = "0.2.4"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -149,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -194,9 +203,9 @@ checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ categories = ["embedded", "no-std", "rust-patterns"]
 [features]
 alloc = []
 default = ["alloc", "zerocopy"]
+derive = ["percore-derive"]
 
 [dependencies]
+percore-derive = { version = "=0.2.4", path = "percore-derive", optional = true }
 zerocopy = { version = "0.8.50", optional = true, features = ["derive"] }
 
 [dev-dependencies]
@@ -29,4 +31,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]
 resolver = "3"
-members = ["examples/aarch64_qemu"]
+members = ["percore-derive", "examples/aarch64_qemu"]
+default-members = [".", "percore-derive"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,141 @@ Currently only aarch32 and aarch64 are fully supported. The crate will build for
 architectures, but you'll need to provide your own implementation of the `exception_free` function.
 Patches are welcome to add support for other architectures.
 
+# Derive
+
+The `derive` feature enables the use of the `#[percore::percore]` attribute which changes global
+variables into per-core variables. This is an orthogonal way of declaring per-core variables to the
+regular `PerCore` based method.
+
+By default, the primary core is assumed to have index `#0`, with the secondary cores following it
+sequentially. Each core has its own per-core area, and these areas are laid out contiguously in
+memory, like an array of sections. Only the primary core's area, represented by the `.percore`
+section, and it contains the initial values for per-core variables. The corresponding areas for the
+secondary cores, represented by the `.percore_secondary` section, are not included in the image.
+The provided functions are suitable for tiny and small memory models.
+
+Projects may use a different memory layout, provided that they copy the initial variable values into
+each secondary core's per-core area and implement the corresponding
+`#[percore::percore_local_offset]` function to retrieve the appropriate offset.
+
+Pros:
+* At the declaration of the variable it is not necessary to have a `Cores` implementation.
+* Each core's per-core variables are packed together which results in more efficient cache
+  utilization.
+* Better performance.
+
+Cons:
+* Can only be used for global variables.
+* More complex setup.
+
+It requires the following actions from the consuming project:
+
+* Call `percore::derive::percore_copy_secondary_data()` on the primary core at boot time.
+* Calculate the local core offset at boot time on each core using
+  `percore_calculate_local_offset(core_index)`.
+* Store this offset in a project specific way.
+* Implement a function that retrieves the previously stored offset and mark it with
+  `#[percore::percore_local_offset]`.
+* Allocate `.percore` and `.percore_secondary` sections in the linker script and mark their
+  boundaries using the `__PERCORE_START__`, `__PERCORE_END__`, `__PERCORE_SECONDARY_START__` and
+  `__PERCORE_SECONDARY_END__` symbols. It is recommended to align these sections to the cache line
+  size but at least to 16 bytes on `AArch64`.
+
+## Example
+
+### Initialization
+
+The primary core initializes the secondary per-core areas. Each secondary core then calculates its
+offset from its linear index and stores it in `TPIDR_EL1` before entering `main`.
+
+```rust
+global_asm!(
+    "init_primary:
+        bl {percore_copy_secondary_data}
+
+    init_secondary:
+        bl calculate_core_index
+        /* X0 now contains the local core's linear index */
+
+        /* Calculate and store local offset */
+        bl {percore_calculate_local_offset}
+        msr tpidr_el1, x0
+
+        b main
+    ",
+    percore_copy_secondary_data = sym percore_copy_secondary_data,
+    percore_calculate_local_offset = sym percore_calculate_local_offset,
+);
+```
+
+### `percore::percore_local_offset` implementation
+
+This implementation returns the offset from `TPIDR_EL1`, the EL1 Software Thread ID Register.
+
+```rust
+#[percore::percore_local_offset]
+pub fn percore_local_offset_hook() -> usize {
+    read_tpidr_el1()
+}
+```
+
+### Linker script
+
+The linker script places the primary core's initialized data in `.percore` and reserves an equally
+sized area for every secondary core in `.percore_secondary`.
+
+```
+.percore : ALIGN(CACHE_LINE_SIZE) {
+    __PERCORE_START__ = .;
+    *(.percore .percore.*)
+    . = ALIGN(CACHE_LINE_SIZE);
+    __PERCORE_END__ = .;
+} >image
+
+.percore_secondary (NOLOAD) : ALIGN(CACHE_LINE_SIZE) {
+    __PERCORE_SECONDARY_START__ = .;
+    . += (__PERCORE_END__ - __PERCORE_START__) * (CORE_COUNT - 1);
+    __PERCORE_SECONDARY_END__ = .;
+} >image
+```
+
+### Usage
+
+All cores will have their own instance of `VARIABLE` that is initialized to 1.
+
+```rust
+#[percore::percore]
+static VARIABLE: u64 = 1;
+
+assert_eq!(1, *VARIABLE.get());
+```
+
+### Accessing from assembly
+
+Assembly code can access the current core's instance by adding the offset in `TPIDR_EL1` to the
+variable's base address. This example increments the local instance of `VARIABLE`.
+
+```rust
+global_asm!(
+    "increment:
+        /* Retrieve base address of the per-core variable */
+        adrp	x0, {VARIABLE}
+        add	x0, x0, :lo12:{VARIABLE}
+
+        /* Add per-core offset stored in TPIDR_EL1 */
+        mrs	x1, tpidr_el1
+        add	x0, x0, x1
+        /* At this point X0 contains the address to the local core's instance of VARIABLE */
+
+        /* Increment the value by one. */
+        ldr	x1, [x0]
+        add	x1, x1, #1
+        str	x1, [x0]
+        ret",
+    sym VARIABLE = PERCORE_BASE_VARIABLE,
+);
+```
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ Patches are welcome to add support for other architectures.
 
 # Derive
 
-The `derive` feature enables the use of the `#[percore::percore]` attribute which changes global
-variables into per-core variables. This is an orthogonal way of declaring per-core variables to the
-regular `PerCore` based method.
+The `derive` feature enables the use of the `#[percore::percore]` attribute, which replaces a static
+with a `LinkedPerCore` of the same name in the `.percore` linker section. The wrapper stores the
+primary core's value and accesses the corresponding copy for the current core. This is an
+alternative to declaring per-core variables with `PerCore`.
 
 By default, the primary core is assumed to have index 0, with the secondary cores following it
 sequentially. Each core has its own per-core area, and these areas are laid out contiguously in
@@ -146,7 +147,7 @@ struct PercoreLocalOffsetImpl;
 // accessing any percore variable.
 unsafe impl PercoreLocalOffset for PercoreLocalOffsetImpl {
     fn percore_local_offset() -> usize {
-        read_tpidr_el1()
+        read_tpidr_el1().threadid() as _
     }
 }
 ```
@@ -211,7 +212,7 @@ global_asm!(
         add	x1, x1, #1
         str	x1, [x0]
         ret",
-    sym VARIABLE = PERCORE_BASE_VARIABLE,
+    VARIABLE = sym VARIABLE,
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ The `derive` feature enables the use of the `#[percore::percore]` attribute whic
 variables into per-core variables. This is an orthogonal way of declaring per-core variables to the
 regular `PerCore` based method.
 
-By default, the primary core is assumed to have index `#0`, with the secondary cores following it
+By default, the primary core is assumed to have index 0, with the secondary cores following it
 sequentially. Each core has its own per-core area, and these areas are laid out contiguously in
 memory, like an array of sections. Only the primary core's area, represented by the `.percore`
-section, and it contains the initial values for per-core variables. The corresponding areas for the
-secondary cores, represented by the `.percore_secondary` section, are not included in the image.
-The provided functions are suitable for tiny and small memory models.
+section is included in the image, and it contains the initial values for per-core variables. The
+corresponding areas for the secondary cores, represented by the `.percore_secondary` section, are
+not included in the image. The provided functions are suitable for tiny and small memory models.
 
 Projects may use a different memory layout, provided that they copy the initial variable values into
-each secondary core's per-core area and implement the corresponding
-`#[percore::percore_local_offset]` function to retrieve the appropriate offset.
+each secondary core's per-core area and implement `percore::derive::PercoreLocalOffset` on a type
+marked with `#[percore::percore_local_offset]` to retrieve the appropriate offset.
 
 Pros:
 * At the declaration of the variable it is not necessary to have a `Cores` implementation.
@@ -88,6 +88,7 @@ Pros:
 Cons:
 * Can only be used for global variables.
 * More complex setup.
+* Currently, this is only implemented for `AArch64` targets.
 
 It requires the following actions from the consuming project:
 
@@ -95,8 +96,8 @@ It requires the following actions from the consuming project:
 * Calculate the local core offset at boot time on each core using
   `percore_calculate_local_offset(core_index)`.
 * Store this offset in a project specific way.
-* Implement a function that retrieves the previously stored offset and mark it with
-  `#[percore::percore_local_offset]`.
+* Implement `percore::derive::PercoreLocalOffset` for a type that retrieves the previously stored
+  offset and mark the type with `#[percore::percore_local_offset]`.
 * Allocate `.percore` and `.percore_secondary` sections in the linker script and mark their
   boundaries using the `__PERCORE_START__`, `__PERCORE_END__`, `__PERCORE_SECONDARY_START__` and
   `__PERCORE_SECONDARY_END__` symbols. It is recommended to align these sections to the cache line
@@ -110,6 +111,8 @@ The primary core initializes the secondary per-core areas. Each secondary core t
 offset from its linear index and stores it in `TPIDR_EL1` before entering `main`.
 
 ```rust
+use core::arch::global_asm;
+
 global_asm!(
     "init_primary:
         bl {percore_copy_secondary_data}
@@ -129,14 +132,22 @@ global_asm!(
 );
 ```
 
-### `percore::percore_local_offset` implementation
+### `PercoreLocalOffsetImpl` implementation
 
 This implementation returns the offset from `TPIDR_EL1`, the EL1 Software Thread ID Register.
 
 ```rust
+use percore::derive::PercoreLocalOffset;
+
 #[percore::percore_local_offset]
-pub fn percore_local_offset_hook() -> usize {
-    read_tpidr_el1()
+struct PercoreLocalOffsetImpl;
+
+// Safety: Each core initializes TPIDR_EL1 with the offset of its valid percore area before
+// accessing any percore variable.
+unsafe impl PercoreLocalOffset for PercoreLocalOffsetImpl {
+    fn percore_local_offset() -> usize {
+        read_tpidr_el1()
+    }
 }
 ```
 
@@ -165,10 +176,17 @@ sized area for every secondary core in `.percore_secondary`.
 All cores will have their own instance of `VARIABLE` that is initialized to 1.
 
 ```rust
-#[percore::percore]
-static VARIABLE: u64 = 1;
+pub use percore::exception_free;
 
-assert_eq!(1, *VARIABLE.get());
+#[percore::percore]
+static VARIABLE: ExceptionLock<RefCell<u64>> = ExceptionLock::new(RefCell::new(1));
+
+exception_free(|token| {
+    assert_eq!(1, *VARIABLE.get().borrow(token));
+
+    *VARIABLE.get().borrow_mut(token) = 2;
+    assert_eq!(2, *VARIABLE.get().borrow(token));
+});
 ```
 
 ### Accessing from assembly

--- a/percore-derive/Cargo.toml
+++ b/percore-derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "percore-derive"
+version = "0.2.4"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Proc-macro for adding percore attribute."
+authors = ["Imre Kis <imre.kis@arm.com>"]
+repository = "https://github.com/google/percore"
+keywords = ["aarch64", "exceptions"]
+categories = ["embedded", "no-std", "rust-patterns"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.45"
+syn = { version = "2.0.118", features = ["full"] }

--- a/percore-derive/LICENSE-APACHE
+++ b/percore-derive/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/percore-derive/LICENSE-MIT
+++ b/percore-derive/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/percore-derive/README.md
+++ b/percore-derive/README.md
@@ -1,0 +1,4 @@
+# Warning
+
+Please **do not use this create directly**, but rather through the `derive` feature of the
+[percore](https://crates.io/crates/percore) crate.

--- a/percore-derive/src/lib.rs
+++ b/percore-derive/src/lib.rs
@@ -3,15 +3,14 @@
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{ItemStatic, ItemStruct, parse_macro_input};
 
 /// Marks the variable as percore, creating an instance for each core.
 ///
-/// * Defines the variable called `PERCORE_BASE_[variable name]` in the percore section. This can
-///   be used for retrieving the base address (the address without the core's local offset) for
-///   accessing the variable from assembly.
-/// * Defines a `PerCoreWrapper` with the original variable name.
+/// This replaces the static with a `percore::derive::LinkedPerCore` of the same name and places it
+/// in the `.percore` linker section. The static's symbol is the base address of the per-core variable
+/// and can be used to access it from assembly.
 #[proc_macro_attribute]
 pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let variable = parse_macro_input!(item as ItemStatic);
@@ -22,17 +21,11 @@ pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let ty = &variable.ty;
     let expr = &variable.expr;
 
-    let percore_base_name = &format_ident!("PERCORE_BASE_{name}");
-
     quote! {
         #[cfg_attr(target_os = "none", unsafe(link_section = ".percore"))]
         #(#attrs)*
-        #vis static mut #percore_base_name: #ty = #expr;
-
-        #(#attrs)*
-        #[doc = concat!("Per-core wrapper for [`", stringify!(#name), "`]")]
-        #vis static #name: percore::derive::PerCoreWrapper<#ty> =
-            percore::derive::PerCoreWrapper::new(unsafe{ &#percore_base_name });
+        #vis static #name: percore::derive::LinkedPerCore<#ty> =
+            unsafe { percore::derive::LinkedPerCore::new(#expr) };
     }
     .into()
 }
@@ -42,11 +35,11 @@ pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// This creates the `percore_local_offset` function used internally by `percore::derive`.
 #[proc_macro_attribute]
 pub fn percore_local_offset(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let variable = parse_macro_input!(item as ItemStruct);
-    let ident = &variable.ident;
+    let struct_item = parse_macro_input!(item as ItemStruct);
+    let ident = &struct_item.ident;
 
     quote! {
-        #variable
+        #struct_item
 
         #[doc(hidden)]
         mod __percore {

--- a/percore-derive/src/lib.rs
+++ b/percore-derive/src/lib.rs
@@ -4,13 +4,14 @@
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{ItemFn, ItemStatic, parse_macro_input};
+use syn::{ItemStatic, ItemStruct, parse_macro_input};
 
 /// Marks the variable as percore, creating an instance for each core.
 ///
-/// * Defines the variable in the percore section
-/// * Creates a wrapper type that provides the get() function.
-/// * Defines an instance of the wrapper.
+/// * Defines the variable called `PERCORE_BASE_[variable name]` in the percore section. This can
+///   be used for retrieving the base address (the address without the core's local offset) for
+///   accessing the variable from assembly.
+/// * Defines a `PerCoreWrapper` with the original variable name.
 #[proc_macro_attribute]
 pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let variable = parse_macro_input!(item as ItemStatic);
@@ -21,49 +22,42 @@ pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let ty = &variable.ty;
     let expr = &variable.expr;
 
-    let percore_name = &format_ident!("PERCORE_BASE_{name}");
-    let wrapper_ty = &format_ident!("PERCORE_WRAPPER_{name}");
+    let percore_base_name = &format_ident!("PERCORE_BASE_{name}");
 
     quote! {
         #[cfg_attr(target_os = "none", unsafe(link_section = ".percore"))]
         #(#attrs)*
-        #vis static mut #percore_name: #ty = #expr;
-
-        #[doc = concat!("Per-core wrapper for [`", stringify!(#name), "`]")]
-        #vis struct #wrapper_ty;
-
-        impl #wrapper_ty {
-            #[doc = "Returns a shared reference to the value of the current CPU."]
-            #[inline(always)]
-            pub fn get(&self) -> &#ty {
-                let offset = unsafe{ percore::derive::percore_local_offset() };
-                unsafe { core::ptr::NonNull::from_ref(&#percore_name).byte_add(offset).as_ref() }
-            }
-        }
+        #vis static mut #percore_base_name: #ty = #expr;
 
         #(#attrs)*
-        #vis static #name: #wrapper_ty = #wrapper_ty;
+        #[doc = concat!("Per-core wrapper for [`", stringify!(#name), "`]")]
+        #vis static #name: percore::derive::PerCoreWrapper<#ty> =
+            percore::derive::PerCoreWrapper::new(unsafe{ &#percore_base_name });
     }
     .into()
 }
 
-/// Marks the function that returns the offset of the local cores percore area in bytes from the
-/// beginning of the percore section.
-/// It creates a `percore_local_offset` wrapper function that is the interface towards
-/// `percore::derive`.
+/// Marks the type that implements `percore::derive::PercoreLocalOffset`.
+///
+/// This creates the `percore_local_offset` function used internally by `percore::derive`.
 #[proc_macro_attribute]
 pub fn percore_local_offset(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let func = parse_macro_input!(item as ItemFn);
-    let ident = &func.sig.ident;
+    let variable = parse_macro_input!(item as ItemStruct);
+    let ident = &variable.ident;
 
     quote! {
-        #func
+        #variable
 
-        #[doc = "percore_local_offset wrapper function."]
-        #[unsafe(no_mangle)]
-        #[inline(always)]
-        pub extern "Rust" fn percore_local_offset() -> usize {
-            #ident()
+        #[doc(hidden)]
+        mod __percore {
+            use super::*;
+
+            #[doc = "percore_local_offset wrapper function."]
+            #[unsafe(no_mangle)]
+            #[inline(always)]
+            fn percore_local_offset() -> usize {
+                <#ident as percore::derive::PercoreLocalOffset>::percore_local_offset()
+            }
         }
     }
     .into()

--- a/percore-derive/src/lib.rs
+++ b/percore-derive/src/lib.rs
@@ -1,0 +1,70 @@
+// Copyright 2026 The percore Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{ItemFn, ItemStatic, parse_macro_input};
+
+/// Marks the variable as percore, creating an instance for each core.
+///
+/// * Defines the variable in the percore section
+/// * Creates a wrapper type that provides the get() function.
+/// * Defines an instance of the wrapper.
+#[proc_macro_attribute]
+pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let variable = parse_macro_input!(item as ItemStatic);
+
+    let attrs = &variable.attrs;
+    let vis = &variable.vis;
+    let name = &variable.ident;
+    let ty = &variable.ty;
+    let expr = &variable.expr;
+
+    let percore_name = &format_ident!("PERCORE_BASE_{name}");
+    let wrapper_ty = &format_ident!("PERCORE_WRAPPER_{name}");
+
+    quote! {
+        #[cfg_attr(target_os = "none", unsafe(link_section = ".percore"))]
+        #(#attrs)*
+        #vis static mut #percore_name: #ty = #expr;
+
+        #[doc = concat!("Per-core wrapper for [`", stringify!(#name), "`]")]
+        #vis struct #wrapper_ty;
+
+        impl #wrapper_ty {
+            #[doc = "Returns a shared reference to the value of the current CPU."]
+            #[inline(always)]
+            pub fn get(&self) -> &#ty {
+                let offset = unsafe{ percore::derive::percore_local_offset() };
+                unsafe { core::ptr::NonNull::from_ref(&#percore_name).byte_add(offset).as_ref() }
+            }
+        }
+
+        #(#attrs)*
+        #vis static #name: #wrapper_ty = #wrapper_ty;
+    }
+    .into()
+}
+
+/// Marks the function that returns the offset of the local cores percore area in bytes from the
+/// beginning of the percore section.
+/// It creates a `percore_local_offset` wrapper function that is the interface towards
+/// `percore::derive`.
+#[proc_macro_attribute]
+pub fn percore_local_offset(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(item as ItemFn);
+    let ident = &func.sig.ident;
+
+    quote! {
+        #func
+
+        #[doc = "percore_local_offset wrapper function."]
+        #[unsafe(no_mangle)]
+        #[inline(always)]
+        pub extern "Rust" fn percore_local_offset() -> usize {
+            #ident()
+        }
+    }
+    .into()
+}

--- a/percore-derive/src/lib.rs
+++ b/percore-derive/src/lib.rs
@@ -13,13 +13,13 @@ use syn::{ItemStatic, ItemStruct, parse_macro_input};
 /// and can be used to access it from assembly.
 #[proc_macro_attribute]
 pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let variable = parse_macro_input!(item as ItemStatic);
+    let static_item = parse_macro_input!(item as ItemStatic);
 
-    let attrs = &variable.attrs;
-    let vis = &variable.vis;
-    let name = &variable.ident;
-    let ty = &variable.ty;
-    let expr = &variable.expr;
+    let attrs = &static_item.attrs;
+    let vis = &static_item.vis;
+    let name = &static_item.ident;
+    let ty = &static_item.ty;
+    let expr = &static_item.expr;
 
     quote! {
         #[cfg_attr(target_os = "none", unsafe(link_section = ".percore"))]

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -8,9 +8,12 @@ mod aarch64;
 #[cfg(all(target_arch = "aarch64", target_os = "none"))]
 pub use aarch64::{percore_calculate_local_offset, percore_copy_secondary_data};
 
+use crate::lock::ExceptionLock;
+use core::ptr::NonNull;
+
 #[cfg(all(target_arch = "aarch64", target_os = "none"))]
 #[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "Rust" {
     /// Symbol marking the start of the percore section.
     static __PERCORE_START__: ();
     /// Symbol marking the end of the percore section.
@@ -21,29 +24,89 @@ unsafe extern "C" {
     static __PERCORE_SECONDARY_END__: ();
 }
 
-unsafe extern "Rust" {
-    /// The consuming project must define the function in a way that it returns the offset of the
-    /// local cores percore area in bytes from the beginning of the percore section. This is done
-    /// by marking a function with the `#[percore::percore_local_offset]` attribute.
-    pub fn percore_local_offset() -> usize;
+/// Provides the offset of the local core's percore area.
+///
+/// The consuming project must implement this trait for a type and mark that type with
+/// `percore_local_offset`.
+///
+/// # Safety
+///
+/// The offset must point point to a valid and initialized percore memory area and it must not
+/// overflow `isize` for any percore variable and core.
+pub unsafe trait PercoreLocalOffset {
+    /// Returns the byte offset of the local core's percore area from the `.percore` section.
+    fn percore_local_offset() -> usize;
 }
+
+unsafe extern "Rust" {
+    /// Returns the byte offset supplied by the type marked with
+    /// [`percore_local_offset`](macro@crate::percore_local_offset).
+    ///
+    /// The [`PercoreLocalOffset`] safety contract guarantees that the offset is valid for every
+    /// per-core variable.
+    pub safe fn percore_local_offset() -> usize;
+}
+
+/// Per-core wrapper for `T`.
+pub struct PerCoreWrapper<T>(NonNull<T>);
+
+impl<T> PerCoreWrapper<T> {
+    /// Creates new instance.
+    pub const fn new(value: &T) -> Self {
+        Self(NonNull::from_ref(value))
+    }
+
+    /// Returns a shared reference to the value of the current CPU.
+    #[inline(always)]
+    pub fn get(&self) -> &T {
+        // Safety: PercoreLocalOffset guarantees a valid offset.
+        let percore_ptr = unsafe { self.0.byte_add(percore_local_offset()) };
+
+        // Safety:
+        // * Alignment: TODO: we need something like const{assert!(core::mem::align_of::<T>() <= CACHE_WRITEBACK_SIZE)}
+        // * The pointer is non-null because it is constructed from NonNull and the offset produces
+        //   a valid address.
+        // * The PercoreLocalOffset implementation promises that the calculated pointer points into
+        // * the percore memory area which is initialized and it is dereferenceable for the T type.
+        // * Aliasing is prevented by each core having it's own instance of the variable and by
+        //   requiring `ExceptionLock` for `Sync` implementation.
+        unsafe { percore_ptr.as_ref() }
+    }
+}
+
+// Safety: `PerCoreWrapper` is safe between different cores, because each core has its own
+// core-local instance of the variable. `ExceptionLock` also prevents concurrent access from runtime
+// and exception context.
+unsafe impl<T: Send> Sync for PerCoreWrapper<ExceptionLock<T>> {}
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate as percore;
+    use crate::ExceptionFree;
+    use core::cell::RefCell;
 
     #[percore::percore]
-    static VALUE: u64 = 0xabcd_ef01_2345_6789;
+    static VALUE: ExceptionLock<RefCell<u64>> =
+        ExceptionLock::new(RefCell::new(0xabcd_ef01_2345_6789));
 
     #[percore::percore_local_offset]
-    pub fn percore_local_offset_hook() -> usize {
-        0
+    struct PercoreLocalOffsetImpl;
+
+    // Safety: Tests use the initialized primary-core value at offset zero.
+    unsafe impl PercoreLocalOffset for PercoreLocalOffsetImpl {
+        fn percore_local_offset() -> usize {
+            0
+        }
     }
 
     #[test]
     fn test_percore_derive() {
-        assert_eq!(0xabcd_ef01_2345_6789, *VALUE.get());
+        let token = unsafe { ExceptionFree::new() };
 
-        assert_eq!(0xabcd_ef01_2345_6789, unsafe { PERCORE_BASE_VALUE });
+        assert_eq!(0xabcd_ef01_2345_6789, *VALUE.get().borrow(token).borrow());
+
+        *VALUE.get().borrow_mut(token) = 10;
+        assert_eq!(10, *VALUE.get().borrow(token).borrow());
     }
 }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -2,6 +2,16 @@
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
+//! Linker section based per-core variables
+//!
+//! The `percore` attribute places a variable's initial value in the `.percore` linker section and
+//! exposes a `LinkedPerCore` wrapper that accesses the copy for the local CPU. The consuming
+//! project must initialize each CPU's percore area and provide its offset by implementing
+//! `PercoreLocalOffset` on a type marked with `percore_local_offset`.
+//!
+//! On AArch64 bare-metal targets, `percore_copy_secondary_data` initializes the secondary percore
+//! areas and `percore_calculate_local_offset` calculates an area's offset from a CPU linear index.
+
 #[cfg(all(target_arch = "aarch64", target_os = "none"))]
 mod aarch64;
 
@@ -31,7 +41,7 @@ unsafe extern "Rust" {
 ///
 /// # Safety
 ///
-/// The offset must point point to a valid and initialized percore memory area and it must not
+/// The offset must point to a valid and initialized percore memory area and it must not
 /// overflow `isize` for any percore variable and core.
 pub unsafe trait PercoreLocalOffset {
     /// Returns the byte offset of the local core's percore area from the `.percore` section.
@@ -47,20 +57,29 @@ unsafe extern "Rust" {
     pub safe fn percore_local_offset() -> usize;
 }
 
-/// Per-core wrapper for `T`.
-pub struct PerCoreWrapper<T>(NonNull<T>);
+/// A value stored in a linker section containing one copy for each CPU.
+///
+/// The primary CPU's value is stored directly in this wrapper. [`get`](Self::get) adds the local
+/// per-core offset to its address to locate the current CPU's copy.
+#[repr(transparent)]
+pub struct LinkedPerCore<T>(T);
 
-impl<T> PerCoreWrapper<T> {
-    /// Creates new instance.
-    pub const fn new(value: &T) -> Self {
-        Self(NonNull::from_ref(value))
+impl<T> LinkedPerCore<T> {
+    /// Creates a new instance containing the primary CPU's value.
+    ///
+    /// # Safety
+    ///
+    /// The created variable must be a static placed in the `.percore` section and the project must
+    /// have a valid `PercoreLocalOffset` implementation.
+    pub const unsafe fn new(value: T) -> Self {
+        Self(value)
     }
 
     /// Returns a shared reference to the value of the current CPU.
     #[inline(always)]
     pub fn get(&self) -> &T {
         // Safety: PercoreLocalOffset guarantees a valid offset.
-        let percore_ptr = unsafe { self.0.byte_add(percore_local_offset()) };
+        let percore_ptr = unsafe { NonNull::from_ref(&self.0).byte_add(percore_local_offset()) };
 
         // Safety:
         // * Alignment: TODO: we need something like const{assert!(core::mem::align_of::<T>() <= CACHE_WRITEBACK_SIZE)}
@@ -68,16 +87,16 @@ impl<T> PerCoreWrapper<T> {
         //   a valid address.
         // * The PercoreLocalOffset implementation promises that the calculated pointer points into
         // * the percore memory area which is initialized and it is dereferenceable for the T type.
-        // * Aliasing is prevented by each core having it's own instance of the variable and by
+        // * Aliasing is prevented by each core having its own instance of the variable and by
         //   requiring `ExceptionLock` for `Sync` implementation.
         unsafe { percore_ptr.as_ref() }
     }
 }
 
-// Safety: `PerCoreWrapper` is safe between different cores, because each core has its own
+// Safety: `LinkedPerCore` is safe between different cores, because each core has its own
 // core-local instance of the variable. `ExceptionLock` also prevents concurrent access from runtime
 // and exception context.
-unsafe impl<T: Send> Sync for PerCoreWrapper<ExceptionLock<T>> {}
+unsafe impl<T: Send> Sync for LinkedPerCore<ExceptionLock<T>> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,0 +1,49 @@
+// Copyright 2026 The percore Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+#[cfg(all(target_arch = "aarch64", target_os = "none"))]
+mod aarch64;
+
+#[cfg(all(target_arch = "aarch64", target_os = "none"))]
+pub use aarch64::{percore_calculate_local_offset, percore_copy_secondary_data};
+
+#[cfg(all(target_arch = "aarch64", target_os = "none"))]
+#[allow(improper_ctypes)]
+unsafe extern "C" {
+    /// Symbol marking the start of the percore section.
+    static __PERCORE_START__: ();
+    /// Symbol marking the end of the percore section.
+    static __PERCORE_END__: ();
+    /// Symbol marking the start of the secondary cores' percore section.
+    static __PERCORE_SECONDARY_START__: ();
+    /// Symbol marking the end of the secondary cores' percore section.
+    static __PERCORE_SECONDARY_END__: ();
+}
+
+unsafe extern "Rust" {
+    /// The consuming project must define the function in a way that it returns the offset of the
+    /// local cores percore area in bytes from the beginning of the percore section. This is done
+    /// by marking a function with the `#[percore::percore_local_offset]` attribute.
+    pub fn percore_local_offset() -> usize;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate as percore;
+
+    #[percore::percore]
+    static VALUE: u64 = 0xabcd_ef01_2345_6789;
+
+    #[percore::percore_local_offset]
+    pub fn percore_local_offset_hook() -> usize {
+        0
+    }
+
+    #[test]
+    fn test_percore_derive() {
+        assert_eq!(0xabcd_ef01_2345_6789, *VALUE.get());
+
+        assert_eq!(0xabcd_ef01_2345_6789, unsafe { PERCORE_BASE_VALUE });
+    }
+}

--- a/src/derive/aarch64.rs
+++ b/src/derive/aarch64.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 The percore Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+use super::{
+    __PERCORE_END__, __PERCORE_SECONDARY_END__, __PERCORE_SECONDARY_START__, __PERCORE_START__,
+};
+use core::arch::naked_asm;
+
+/// Duplicates the contents of the initialised percore section into the secondary cores' percore
+/// area. The function is safe to be called from assembly without a stack present. It clobbers
+/// registers X0-X6.
+///
+/// The function calculates the size of the percore section as the difference between the
+/// __PERCORE_START__ and __PERCORE_END__ symbols. Then it copies this memory area between the
+/// __PERCORE_SECONDARY_START__ and __PERCORE_SECONDARY_END__ symbols as many times as it fits.
+/// The copy is done in 16 byte chunks, so these symbols must be aligned to at least a 16 byte
+/// boundary. The function is suitable for tiny and small memory models.
+#[unsafe(naked)]
+pub extern "C" fn percore_copy_secondary_data() {
+    naked_asm!(
+        "adrp	x0, {PERCORE_START}
+        add	x0, x0, :lo12:{PERCORE_START}
+        adrp	x1, {PERCORE_END}
+        add	x1, x1, :lo12:{PERCORE_END}
+        adrp	x2, {PERCORE_SECONDARY_START}
+        add	x2, x2, :lo12:{PERCORE_SECONDARY_START}
+        adrp	x3, {PERCORE_SECONDARY_END}
+        add	x3, x3, :lo12:{PERCORE_SECONDARY_END}
+
+        /* Check whether the percore section is empty. */
+        cmp	x0, x1
+        b.eq	3f
+
+        /* Check whether the percore_secondary section is empty, i.e. no secondary cores */
+        cmp	x2, x3
+        b.eq	3f
+
+        /* Save source start pointer */
+        mov	x4, x0
+
+        /*
+         * Per-core loop
+         * X0: src
+         * X1: src_end
+         * X2: dst
+         * X3: dst_end (end of the percore area of the last core)
+         * X5, X6: data temp
+         */
+
+    1:
+        mov	x0, x4
+
+        /* Data loop */
+    2:
+        ldp	x5, x6, [x0], #16
+        stp	x5, x6, [x2], #16
+
+        /* src == src_end */
+        cmp	x0, x1
+        b.ne	2b
+
+        /* dst == dst_end */
+        cmp	x2, x3
+        b.ne	1b
+
+    3:
+        ret",
+        PERCORE_START = sym __PERCORE_START__,
+        PERCORE_END = sym __PERCORE_END__,
+        PERCORE_SECONDARY_START = sym __PERCORE_SECONDARY_START__,
+        PERCORE_SECONDARY_END = sym __PERCORE_SECONDARY_END__,
+    )
+}
+
+/// Calculates the offset of the core's percore area from the percore sections beginning using the
+/// following formula: `(__PERCORE_END__ - __PERCORE_START__) * core_index`. The intended use of
+/// this function is to use its output to set the offset register of the core. The function is safe
+/// to be called from assembly without a stack present. It clobbers registers X0-X2 and returns the
+/// offset in X0. The function is suitable for tiny and small memory models.
+#[unsafe(naked)]
+pub extern "C" fn percore_calculate_local_offset(core_index: usize) -> usize {
+    naked_asm!(
+        "adrp	x1, {PERCORE_START}
+        add	x1, x1, :lo12:{PERCORE_START}
+        adrp	x2, {PERCORE_END}
+        add	x2, x2, :lo12:{PERCORE_END}
+        sub	x1, x2, x1
+        mul	x0, x0, x1
+        ret",
+        PERCORE_START = sym __PERCORE_START__,
+        PERCORE_END = sym __PERCORE_END__,
+    )
+}

--- a/src/derive/aarch64.rs
+++ b/src/derive/aarch64.rs
@@ -19,7 +19,8 @@ use core::arch::naked_asm;
 #[unsafe(naked)]
 pub extern "C" fn percore_copy_secondary_data() {
     naked_asm!(
-        "adrp	x0, {PERCORE_START}
+        "bti	c
+        adrp	x0, {PERCORE_START}
         add	x0, x0, :lo12:{PERCORE_START}
         adrp	x1, {PERCORE_END}
         add	x1, x1, :lo12:{PERCORE_END}
@@ -81,7 +82,8 @@ pub extern "C" fn percore_copy_secondary_data() {
 #[unsafe(naked)]
 pub extern "C" fn percore_calculate_local_offset(core_index: usize) -> usize {
     naked_asm!(
-        "adrp	x1, {PERCORE_START}
+        "bti	c
+        adrp	x1, {PERCORE_START}
         add	x1, x1, :lo12:{PERCORE_START}
         adrp	x2, {PERCORE_END}
         add	x2, x2, :lo12:{PERCORE_END}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,15 @@ mod boxed;
 mod exceptions;
 mod lock;
 
+#[cfg(feature = "derive")]
+pub mod derive;
+
 #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
 pub use self::exceptions::exception_free;
 pub use self::{exceptions::ExceptionFree, lock::ExceptionLock};
+
+#[cfg(feature = "derive")]
+pub use percore_derive::{percore, percore_local_offset};
 
 use core::marker::PhantomData;
 


### PR DESCRIPTION
Add a new `derive` feature backed by the `percore-derive` proc-macro crate. The `#[percore::percore]` attribute places statics in the `.percore` section, generates a wrapper type, and exposes per-core access through the runtime offset hook.