### PR TITLE
Cleanups, improvements and documentation for percore derive

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,12 +27,20 @@ jobs:
           target: armv7a-none-eabi
       - name: Build
         run: cargo build
+      - name: Build with all features
+        run: cargo build --all-features
       - name: Build for armv7a-none-eabi
         run: cargo build --target=armv7a-none-eabi
+      - name: Build for armv7a-none-eabi with all features
+        run: cargo build --target=armv7a-none-eabi --all-features
       - name: Build for x86_64-unknown-linux-gnu
         run: cargo build --target=x86_64-unknown-linux-gnu
+      - name: Build for x86_64-unknown-linux-gnu with all features
+        run: cargo build --target=x86_64-unknown-linux-gnu --all-features
       - name: Run tests
         run: cargo test --target=x86_64-unknown-linux-gnu
+      - name: Run tests with all features
+        run: cargo test --target=x86_64-unknown-linux-gnu --all-features
       - name: Build examples
         run: cargo build -p aarch64-qemu
       - name: Run clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New features
 
-- Added `percore-derive` and `derive` feature.
+- Added `derive` feature. This provides the `#[percore]` macro for another approach to per-core
+  variables.
 
 ## 0.2.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
 name = "percore-derive"
 version = "0.2.4"
 dependencies = [
+ "percore",
  "quote",
  "syn",
 ]

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ sized area for every secondary core in `.percore_secondary`.
     __PERCORE_END__ = .;
 } >image
 
+ASSERT(
+    ALIGNOF(.percore) <= CACHE_LINE_SIZE,
+    ".percore contains an object aligned to a larger boundary than the section's alignment."
+)
+
 .percore_secondary (NOLOAD) : ALIGN(CACHE_LINE_SIZE) {
     __PERCORE_SECONDARY_START__ = .;
     . += (__PERCORE_END__ - __PERCORE_START__) * (CORE_COUNT - 1);

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ global_asm!(
 This implementation returns the offset from `TPIDR_EL1`, the EL1 Software Thread ID Register.
 
 ```rust
-use percore::derive::PercoreLocalOffset;
+use percore::{derive::PercoreLocalOffset, percore_local_offset};
 
-#[percore::percore_local_offset]
+percore_local_offset!(PercoreLocalOffsetImpl);
 struct PercoreLocalOffsetImpl;
 
 // Safety: Each core initializes TPIDR_EL1 with the offset of its valid percore area before

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ struct PercoreLocalOffsetImpl;
 // Safety: Each core initializes TPIDR_EL1 with the offset of its valid percore area before
 // accessing any percore variable.
 unsafe impl PercoreLocalOffset for PercoreLocalOffsetImpl {
-    fn percore_local_offset() -> usize {
+    fn percore_local_offset() -> isize {
         read_tpidr_el1().threadid() as _
     }
 }

--- a/README.md
+++ b/README.md
@@ -81,25 +81,27 @@ each secondary core's per-core area and implement `percore::derive::PercoreLocal
 marked with `#[percore::percore_local_offset]` to retrieve the appropriate offset.
 
 Pros:
-* At the declaration of the variable it is not necessary to have a `Cores` implementation.
-* Each core's per-core variables are packed together which results in more efficient cache
+
+- At the declaration of the variable it is not necessary to have a `Cores` implementation.
+- Each core's per-core variables are packed together which results in more efficient cache
   utilization.
-* Better performance.
+- Better performance.
 
 Cons:
-* Can only be used for global variables.
-* More complex setup.
-* Currently, this is only implemented for `AArch64` targets.
+
+- Can only be used for global variables.
+- More complex setup.
+- Currently, this is only implemented for `AArch64` targets.
 
 It requires the following actions from the consuming project:
 
-* Call `percore::derive::percore_copy_secondary_data()` on the primary core at boot time.
-* Calculate the local core offset at boot time on each core using
+- Call `percore::derive::percore_copy_secondary_data()` on the primary core at boot time.
+- Calculate the local core offset at boot time on each core using
   `percore_calculate_local_offset(core_index)`.
-* Store this offset in a project specific way.
-* Implement `percore::derive::PercoreLocalOffset` for a type that retrieves the previously stored
+- Store this offset in a project specific way.
+- Implement `percore::derive::PercoreLocalOffset` for a type that retrieves the previously stored
   offset and mark the type with `#[percore::percore_local_offset]`.
-* Allocate `.percore` and `.percore_secondary` sections in the linker script and mark their
+- Allocate `.percore` and `.percore_secondary` sections in the linker script and mark their
   boundaries using the `__PERCORE_START__`, `__PERCORE_END__`, `__PERCORE_SECONDARY_START__` and
   `__PERCORE_SECONDARY_END__` symbols. It is recommended to align these sections to the cache line
   size but at least to 16 bytes on `AArch64`.
@@ -160,7 +162,7 @@ sized area for every secondary core in `.percore_secondary`.
 ```
 .percore : ALIGN(CACHE_LINE_SIZE) {
     __PERCORE_START__ = .;
-    *(.percore .percore.*)
+    *(SORT_BY_ALIGNMENT(.percore .percore.*))
     . = ALIGN(CACHE_LINE_SIZE);
     __PERCORE_END__ = .;
 } >image
@@ -174,19 +176,20 @@ sized area for every secondary core in `.percore_secondary`.
 
 ### Usage
 
-All cores will have their own instance of `VARIABLE` that is initialized to 1.
+All cores will have their own instance of `VARIABLE` which is initialized to 1.
 
 ```rust
-pub use percore::exception_free;
+use core::cell::RefCell;
+use percore::{ExceptionLock, exception_free, percore};
 
 #[percore::percore]
 static VARIABLE: ExceptionLock<RefCell<u64>> = ExceptionLock::new(RefCell::new(1));
 
 exception_free(|token| {
-    assert_eq!(1, *VARIABLE.get().borrow(token));
+    assert_eq!(1, *VARIABLE.get().borrow_mut(token));
 
     *VARIABLE.get().borrow_mut(token) = 2;
-    assert_eq!(2, *VARIABLE.get().borrow(token));
+    assert_eq!(2, *VARIABLE.get().borrow_mut(token));
 });
 ```
 

--- a/examples/aarch64_qemu/qemu.ld
+++ b/examples/aarch64_qemu/qemu.ld
@@ -21,6 +21,11 @@ SECTIONS
 		__PERCORE_END__ = .;
 	} >image
 
+	ASSERT(
+		ALIGNOF(.percore) <= 16,
+		".percore contains an object aligned to a larger boundary than the sections alignment"
+	)
+
 	.percore_secondary (NOLOAD) : ALIGN(16) {
 		__PERCORE_SECONDARY_START__ = .;
 		. += (__PERCORE_END__ - __PERCORE_START__) * (CORE_COUNT - 1);

--- a/examples/aarch64_qemu/src/macro.rs
+++ b/examples/aarch64_qemu/src/macro.rs
@@ -21,8 +21,10 @@ use core::{
 };
 use percore::{
     Cores, ExceptionLock,
-    derive::{PercoreLocalOffset, percore_calculate_local_offset, percore_copy_secondary_data},
-    exception_free, percore, percore_local_offset,
+    derive::{
+        PercoreLocalOffset, percore, percore_calculate_local_offset, percore_copy_secondary_data,
+    },
+    exception_free, percore_local_offset,
 };
 use smccc::{
     Hvc,

--- a/examples/aarch64_qemu/src/macro.rs
+++ b/examples/aarch64_qemu/src/macro.rs
@@ -73,6 +73,8 @@ unsafe impl PercoreLocalOffset for PercoreLocalOffsetImpl {
 #[percore]
 static STATE: ExceptionLock<RefCell<u32>> = ExceptionLock::new(RefCell::new(42));
 
+static PERCORE_INITIALISED: AtomicBool = AtomicBool::new(false);
+
 entry!(main);
 /// Entry point for primary core.
 fn main(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> ! {
@@ -91,6 +93,7 @@ fn main(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> ! {
         // Initialise percore variables for secondary cores.
         percore_copy_secondary_data();
     }
+    PERCORE_INITIALISED.store(true, Ordering::Release);
 
     // Initialise TPIDR_EL1 for the primary core.
     set_local_offset();
@@ -128,6 +131,11 @@ fn main(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> ! {
 /// Entry point for secondary core.
 fn secondary_main() {
     set_local_offset();
+
+    // Ensure that the percore initialisation happens-before we try to access any percore variables.
+    while !PERCORE_INITIALISED.load(Ordering::Acquire) {
+        spin_loop();
+    }
 
     // Access the state for the secondary core.
     exception_free(|token| {

--- a/examples/aarch64_qemu/src/macro.rs
+++ b/examples/aarch64_qemu/src/macro.rs
@@ -22,7 +22,9 @@ use core::{
 use percore::{
     Cores, ExceptionLock,
     derive::{
-        PercoreLocalOffset, percore, percore_calculate_local_offset, percore_copy_secondary_data,
+        PercoreLocalOffset,
+        aarch64::{percore_calculate_local_offset, percore_copy_secondary_data},
+        percore,
     },
     exception_free, percore_local_offset,
 };

--- a/examples/aarch64_qemu/src/macro.rs
+++ b/examples/aarch64_qemu/src/macro.rs
@@ -54,7 +54,7 @@ unsafe impl Cores for CoresImpl {
     }
 }
 
-#[percore_local_offset]
+percore_local_offset!(PercoreLocalOffsetImpl);
 struct PercoreLocalOffsetImpl;
 
 // SAFETY: Each core initialises TPIDR_EL1 with the offset of its percore area before any code that

--- a/examples/aarch64_qemu/src/macro.rs
+++ b/examples/aarch64_qemu/src/macro.rs
@@ -60,7 +60,7 @@ struct PercoreLocalOffsetImpl;
 // SAFETY: Each core initialises TPIDR_EL1 with the offset of its percore area before any code that
 // accesses percore variables.
 unsafe impl PercoreLocalOffset for PercoreLocalOffsetImpl {
-    fn percore_local_offset() -> usize {
+    fn percore_local_offset() -> isize {
         read_tpidr_el1().threadid() as _
     }
 }

--- a/examples/aarch64_qemu/src/macro.rs
+++ b/examples/aarch64_qemu/src/macro.rs
@@ -82,8 +82,11 @@ fn main(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> ! {
     )
     .unwrap();
 
-    // Initialise percore variables for secondary cores.
-    percore_copy_secondary_data();
+    // SAFETY: No percore variables are accessed before this call.
+    unsafe {
+        // Initialise percore variables for secondary cores.
+        percore_copy_secondary_data();
+    }
 
     // Initialise TPIDR_EL1 for the primary core.
     set_local_offset();

--- a/percore-derive/Cargo.toml
+++ b/percore-derive/Cargo.toml
@@ -15,3 +15,6 @@ proc-macro = true
 [dependencies]
 quote = "1.0.45"
 syn = { version = "2.0.118", features = ["full"] }
+
+[dev-dependencies]
+percore = { version = "=0.2.4", features = ["derive"], path = ".." }

--- a/percore-derive/src/lib.rs
+++ b/percore-derive/src/lib.rs
@@ -48,7 +48,7 @@ pub fn percore_local_offset(_attr: TokenStream, item: TokenStream) -> TokenStrea
             #[doc = "percore_local_offset wrapper function."]
             #[unsafe(no_mangle)]
             #[inline(always)]
-            fn percore_local_offset() -> usize {
+            fn percore_local_offset() -> isize {
                 <#ident as percore::derive::PercoreLocalOffset>::percore_local_offset()
             }
         }

--- a/percore-derive/src/lib.rs
+++ b/percore-derive/src/lib.rs
@@ -11,6 +11,16 @@ use syn::{ItemStatic, parse_macro_input};
 /// This replaces the static with a `percore::derive::LinkedPerCore` of the same name and places it
 /// in the `.percore` linker section. The static's symbol is the base address of the per-core variable
 /// and can be used to access it from assembly.
+///
+/// # Example
+///
+/// ```
+/// use percore::{ExceptionLock, derive::percore};
+/// use core::cell::RefCell;
+///
+/// #[percore]
+/// static VARIABLE: ExceptionLock<RefCell<u64>> = ExceptionLock::new(RefCell::new(1));
+/// ```
 #[proc_macro_attribute]
 pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let static_item = parse_macro_input!(item as ItemStatic);

--- a/percore-derive/src/lib.rs
+++ b/percore-derive/src/lib.rs
@@ -4,7 +4,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{ItemStatic, ItemStruct, parse_macro_input};
+use syn::{ItemStatic, parse_macro_input};
 
 /// Marks the variable as percore, creating an instance for each core.
 ///
@@ -26,32 +26,6 @@ pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #(#attrs)*
         #vis static #name: percore::derive::LinkedPerCore<#ty> =
             unsafe { percore::derive::LinkedPerCore::new(#expr) };
-    }
-    .into()
-}
-
-/// Marks the type that implements `percore::derive::PercoreLocalOffset`.
-///
-/// This creates the `percore_local_offset` function used internally by `percore::derive`.
-#[proc_macro_attribute]
-pub fn percore_local_offset(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let struct_item = parse_macro_input!(item as ItemStruct);
-    let ident = &struct_item.ident;
-
-    quote! {
-        #struct_item
-
-        #[doc(hidden)]
-        mod __percore {
-            use super::*;
-
-            #[doc = "percore_local_offset wrapper function."]
-            #[unsafe(no_mangle)]
-            #[inline(always)]
-            fn percore_local_offset() -> isize {
-                <#ident as percore::derive::PercoreLocalOffset>::percore_local_offset()
-            }
-        }
     }
     .into()
 }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -21,6 +21,11 @@
 //!     . = ALIGN(CACHE_LINE_SIZE);
 //!     __PERCORE_END__ = .;
 //! } >image
+//!
+//! ASSERT(
+//!     ALIGNOF(.percore) <= CACHE_LINE_SIZE,
+//!     ".percore contains an object aligned to a larger boundary than the section's alignment."
+//! )
 //! ```
 //!
 //! # Initialisation
@@ -44,6 +49,9 @@
 //!    this case there is no distinction between primary and secondary cores, and the original
 //!    `.percore` section must never be modified (or at least not until all cores have started and
 //!    initialised their copies).
+//!
+//! In any case, you must ensure that the alignmeant of each CPU's percore area is greater than or
+//! equal to to the maximum alignment of any percore variable.
 //!
 //! # Usage
 //!
@@ -176,8 +184,13 @@ impl<T> LinkedPerCore<T> {
         // Safety: PercoreLocalOffset guarantees a valid offset.
         let percore_ptr = unsafe { NonNull::from_ref(&self.0).byte_offset(percore_local_offset()) };
 
+        debug_assert!(percore_ptr.is_aligned());
+
         // Safety:
-        // * Alignment: TODO: we need something like const{assert!(core::mem::align_of::<T>() <= CACHE_WRITEBACK_SIZE)}
+        // * The percore region must be aligned to the maximum alignment of any percore variable,
+        //   and `&self.0` must be aligned as it comes from a reference, so adding the offset to it
+        //   must still be properly aligned. (In debug builds we also double-check with the
+        //   debug_assert above.)
         // * The pointer is non-null because it is constructed from NonNull and the offset produces
         //   a valid address.
         // * The PercoreLocalOffset implementation promises that the calculated pointer points into

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -45,7 +45,7 @@ unsafe extern "Rust" {
 /// overflow `isize` for any percore variable and core.
 pub unsafe trait PercoreLocalOffset {
     /// Returns the byte offset of the local core's percore area from the `.percore` section.
-    fn percore_local_offset() -> usize;
+    fn percore_local_offset() -> isize;
 }
 
 unsafe extern "Rust" {
@@ -54,7 +54,7 @@ unsafe extern "Rust" {
     ///
     /// The [`PercoreLocalOffset`] safety contract guarantees that the offset is valid for every
     /// per-core variable.
-    pub safe fn percore_local_offset() -> usize;
+    pub safe fn percore_local_offset() -> isize;
 }
 
 /// A value stored in a linker section containing one copy for each CPU.
@@ -86,7 +86,7 @@ impl<T> LinkedPerCore<T> {
     #[inline(always)]
     pub fn get(&self) -> &T {
         // Safety: PercoreLocalOffset guarantees a valid offset.
-        let percore_ptr = unsafe { NonNull::from_ref(&self.0).byte_add(percore_local_offset()) };
+        let percore_ptr = unsafe { NonNull::from_ref(&self.0).byte_offset(percore_local_offset()) };
 
         // Safety:
         // * Alignment: TODO: we need something like const{assert!(core::mem::align_of::<T>() <= CACHE_WRITEBACK_SIZE)}
@@ -121,7 +121,7 @@ mod tests {
 
     // Safety: Tests use the initialized primary-core value at offset zero.
     unsafe impl PercoreLocalOffset for PercoreLocalOffsetImpl {
-        fn percore_local_offset() -> usize {
+        fn percore_local_offset() -> isize {
             0
         }
     }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -143,7 +143,7 @@ unsafe extern "Rust" {
     ///
     /// The [`PercoreLocalOffset`] safety contract guarantees that the offset is valid for every
     /// per-core variable.
-    pub safe fn percore_local_offset() -> isize;
+    safe fn percore_local_offset() -> isize;
 }
 
 /// A value stored in a linker section containing one copy for each CPU core.

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -61,16 +61,23 @@ unsafe extern "Rust" {
 ///
 /// The primary CPU's value is stored directly in this wrapper. [`get`](Self::get) adds the local
 /// per-core offset to its address to locate the current CPU's copy.
+///
+/// This should generally not be constructed directly, but through the [`percore`](crate::percore)
+/// macro.
 #[repr(transparent)]
 pub struct LinkedPerCore<T>(T);
 
 impl<T> LinkedPerCore<T> {
     /// Creates a new instance containing the primary CPU's value.
     ///
+    /// This should generally not be called directly, but through the [`percore`](crate::percore)
+    /// macro.
+    ///
     /// # Safety
     ///
     /// The created variable must be a static placed in the `.percore` section and the project must
-    /// have a valid `PercoreLocalOffset` implementation.
+    /// have a valid `PercoreLocalOffset` implementation. It must only be accessed after
+    /// `percore_copy_secondary_data` has run.
     pub const unsafe fn new(value: T) -> Self {
         Self(value)
     }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -13,26 +13,61 @@
 //! areas and `percore_calculate_local_offset` calculates an area's offset from a CPU linear index.
 
 #[cfg(all(target_arch = "aarch64", target_os = "none"))]
-mod aarch64;
-
-#[cfg(all(target_arch = "aarch64", target_os = "none"))]
-pub use aarch64::{percore_calculate_local_offset, percore_copy_secondary_data};
+pub mod aarch64;
 
 use crate::lock::ExceptionLock;
 use core::ptr::NonNull;
 pub use percore_derive::percore;
 
-#[cfg(all(target_arch = "aarch64", target_os = "none"))]
 #[allow(improper_ctypes)]
 unsafe extern "Rust" {
-    /// Symbol marking the start of the percore section.
-    static __PERCORE_START__: ();
-    /// Symbol marking the end of the percore section.
-    static __PERCORE_END__: ();
-    /// Symbol marking the start of the secondary cores' percore section.
-    static __PERCORE_SECONDARY_START__: ();
-    /// Symbol marking the end of the secondary cores' percore section.
-    static __PERCORE_SECONDARY_END__: ();
+    /// Symbol marking the start of the `.percore` section.
+    pub safe static __PERCORE_START__: ();
+    /// Symbol marking the end of the `.percore` section.
+    pub safe static __PERCORE_END__: ();
+}
+
+/// Returns the size in bytes of a single core's `.percore` section.
+pub fn percore_size() -> usize {
+    &raw const __PERCORE_END__ as usize - &raw const __PERCORE_START__ as usize
+}
+
+/// Duplicates the contents of the initialised percore section into the secondary cores' percore
+/// area.
+///
+/// The function calculates the size of the `.percore` section as the difference between the
+/// `__PERCORE_START__` and `__PERCORE_END__` symbols. Then it copies this memory area into the
+/// given `secondary_percore_area` as many times as it fits.
+///
+/// Panics if the length of `secondary_percore_area` isn't a multiple of the size of the `.percore`
+/// section.
+///
+/// # Safety
+///
+/// This must only be called before any core accesses any percore variable.
+///
+/// `secondary_percore_area` must be valid for writes, and must not overlap with the `.percore
+/// section.
+///
+/// You must ensure that this initialisation happens-before any percore variables are accessed
+/// (according to Rust's memory model). This could for example be achieved by writing to an
+/// AtomicBool with release semantics and having other cores wait until they see the written value
+/// with acquire semantics.
+pub unsafe fn percore_copy_secondary_data(secondary_percore_area: *mut [u8]) {
+    let percore_start = (&raw const __PERCORE_START__).cast::<u8>();
+    let percore_size = percore_size();
+
+    assert!(secondary_percore_area.len().is_multiple_of(percore_size));
+    let copies = secondary_percore_area.len() / percore_size;
+
+    for i in 0..copies {
+        let dest = (secondary_percore_area as *mut u8).wrapping_byte_add(i * percore_size);
+        // SAFETY: The caller promises that `secondary_percore_area` is valid to write and doesn't
+        // overlap with the `.percore` section.
+        unsafe {
+            percore_start.copy_to_nonoverlapping(dest, percore_size);
+        }
+    }
 }
 
 /// Provides the offset of the local core's percore area.

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -20,6 +20,7 @@ pub use aarch64::{percore_calculate_local_offset, percore_copy_secondary_data};
 
 use crate::lock::ExceptionLock;
 use core::ptr::NonNull;
+pub use percore_derive::percore;
 
 #[cfg(all(target_arch = "aarch64", target_os = "none"))]
 #[allow(improper_ctypes)]
@@ -62,16 +63,14 @@ unsafe extern "Rust" {
 /// The primary CPU's value is stored directly in this wrapper. [`get`](Self::get) adds the local
 /// per-core offset to its address to locate the current CPU's copy.
 ///
-/// This should generally not be constructed directly, but through the [`percore`](crate::percore)
-/// macro.
+/// This should generally not be constructed directly, but through the [`percore`] macro.
 #[repr(transparent)]
 pub struct LinkedPerCore<T>(T);
 
 impl<T> LinkedPerCore<T> {
     /// Creates a new instance containing the primary CPU's value.
     ///
-    /// This should generally not be called directly, but through the [`percore`](crate::percore)
-    /// macro.
+    /// This should generally not be called directly, but through the [`percore`] macro.
     ///
     /// # Safety
     ///
@@ -141,7 +140,7 @@ mod tests {
     use crate::ExceptionFree;
     use core::cell::RefCell;
 
-    #[percore::percore]
+    #[percore]
     static VALUE: ExceptionLock<RefCell<u64>> =
         ExceptionLock::new(RefCell::new(0xabcd_ef01_2345_6789));
 

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -105,6 +105,35 @@ impl<T> LinkedPerCore<T> {
 // and exception context.
 unsafe impl<T: Send> Sync for LinkedPerCore<ExceptionLock<T>> {}
 
+/// Marks the type that implements [`PercoreLocalOffset`].
+///
+/// This creates the `percore_local_offset` function used internally by `percore::derive`.
+///
+/// # Example
+///
+/// ```
+/// use percore::{derive::PercoreLocalOffset, percore_local_offset};
+///
+/// percore_local_offset!(LocalOffsetImpl);
+/// struct LocalOffsetImpl;
+///
+/// unsafe impl PercoreLocalOffset for LocalOffsetImpl {
+///     fn percore_local_offset() -> isize {
+///         todo!("Return the appropriate offset for the current core")
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! percore_local_offset {
+    ($t:ident) => {
+        #[doc(hidden)]
+        #[unsafe(export_name = "percore_local_offset")]
+        fn __percore_local_offset() -> isize {
+            <$t as $crate::derive::PercoreLocalOffset>::percore_local_offset()
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,7 +145,7 @@ mod tests {
     static VALUE: ExceptionLock<RefCell<u64>> =
         ExceptionLock::new(RefCell::new(0xabcd_ef01_2345_6789));
 
-    #[percore::percore_local_offset]
+    percore_local_offset!(PercoreLocalOffsetImpl);
     struct PercoreLocalOffsetImpl;
 
     // Safety: Tests use the initialized primary-core value at offset zero.

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -9,8 +9,61 @@
 //! project must initialize each CPU's percore area and provide its offset by implementing
 //! `PercoreLocalOffset` on a type marked with `percore_local_offset`.
 //!
-//! On AArch64 bare-metal targets, `percore_copy_secondary_data` initializes the secondary percore
-//! areas and `percore_calculate_local_offset` calculates an area's offset from a CPU linear index.
+//! # Linker script
+//!
+//! You must include the `.percore` section in your linker script, with `__PERCORE_START__` and
+//! `__PERCORE_END__` symbols to mark its boundaries. E.g.:
+//!
+//! ```ld
+//! .percore : ALIGN(CACHE_LINE_SIZE) {
+//!     __PERCORE_START__ = .;
+//!     *(SORT_BY_ALIGNMENT(.percore .percore.*))
+//!     . = ALIGN(CACHE_LINE_SIZE);
+//!     __PERCORE_END__ = .;
+//! } >image
+//! ```
+//!
+//! # Initialisation
+//!
+//! Three possible ways to allocate and initialise each CPU's percore area are:
+//!
+//! 1. If you know the number of cores at build time, allocate a `.percore_secondary` section for it
+//!    in your linker script, and provide the `__PERCORE_SECONDARY_START__` and
+//!    `__PERCORE_SECONDARY_END__` symbols. Copy the appropriate number of copies of the `.percore`
+//!    section to this section in assembly code before any Rust code runs. On AArch64 bare-metal
+//!    targets [`aarch64::percore_copy_secondary_data`] is provided to implement this, and
+//!    [`aarch64::percore_calculate_local_offset`] to calculate the area's offset from a CPU linear
+//!    index. This must either be done before caches are enabled or with appropriate cache
+//!    maintenance operations to ensure that it is visible to all cores.
+//! 2. In your Rust entry point before any access to percore variables, copy the appropriate number
+//!    of copies of the `.percore` section to an appropriately sized area of memory.
+//!    [`percore_copy_secondary_data`] is provided to implement this. In this case you must use Rust
+//!    synchronisation primitives (e.g. an AtomicBool) to ensure that this happens-before any access
+//!    to percore variables.
+//! 3. Have each core initialise its own copy of the `.percore` section the first time it starts. In
+//!    this case there is no distinction between primary and secondary cores, and the original
+//!    `.percore` section must never be modified (or at least not until all cores have started and
+//!    initialised their copies).
+//!
+//! # Usage
+//!
+//! All cores will have their own instance of `VARIABLE` which is initialized to 1.
+//!
+//! ```
+//! # fn exception_free<T>(f: impl FnOnce(percore::ExceptionFree<'_>) -> T) {}
+//! use core::cell::RefCell;
+//! use percore::{ExceptionLock, derive::percore};
+//!
+//! #[percore]
+//! static VARIABLE: ExceptionLock<RefCell<u64>> = ExceptionLock::new(RefCell::new(1));
+//!
+//! exception_free(|token| {
+//!     assert_eq!(1, *VARIABLE.get().borrow_mut(token));
+//!
+//!     *VARIABLE.get().borrow_mut(token) = 2;
+//!     assert_eq!(2, *VARIABLE.get().borrow_mut(token));
+//! });
+//! ```
 
 #[cfg(all(target_arch = "aarch64", target_os = "none"))]
 pub mod aarch64;
@@ -72,8 +125,8 @@ pub unsafe fn percore_copy_secondary_data(secondary_percore_area: *mut [u8]) {
 
 /// Provides the offset of the local core's percore area.
 ///
-/// The consuming project must implement this trait for a type and mark that type with
-/// `percore_local_offset`.
+/// The consuming project must implement this trait for a type and mark that type with the
+/// [`percore_local_offset!`](crate::percore_local_offset) macro.
 ///
 /// # Safety
 ///
@@ -93,17 +146,18 @@ unsafe extern "Rust" {
     pub safe fn percore_local_offset() -> isize;
 }
 
-/// A value stored in a linker section containing one copy for each CPU.
+/// A value stored in a linker section containing one copy for each CPU core.
 ///
-/// The primary CPU's value is stored directly in this wrapper. [`get`](Self::get) adds the local
-/// per-core offset to its address to locate the current CPU's copy.
+/// The initial value (which may also be primary core's value) is stored directly in this wrapper.
+/// [`get`](Self::get) adds the local per-core offset to its address to locate the current core's
+/// copy.
 ///
 /// This should generally not be constructed directly, but through the [`percore`] macro.
 #[repr(transparent)]
 pub struct LinkedPerCore<T>(T);
 
 impl<T> LinkedPerCore<T> {
-    /// Creates a new instance containing the primary CPU's value.
+    /// Creates a new instance containing the primary core's value.
     ///
     /// This should generally not be called directly, but through the [`percore`] macro.
     ///
@@ -116,7 +170,7 @@ impl<T> LinkedPerCore<T> {
         Self(value)
     }
 
-    /// Returns a shared reference to the value of the current CPU.
+    /// Returns a shared reference to the value for the current CPU core.
     #[inline(always)]
     pub fn get(&self) -> &T {
         // Safety: PercoreLocalOffset guarantees a valid offset.

--- a/src/derive/aarch64.rs
+++ b/src/derive/aarch64.rs
@@ -2,6 +2,24 @@
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
+//! Assembly implementations of percore initialisation helper functions for AArch64 bare-metal
+//! targets where the number of cores is known at build time.
+//!
+//! These assume that your linker script has a `.percore_secondary` section located immediately
+//! after the `.percore` section, with `__PERCORE_SECONDARY_START__` and `__PERCORE_SECONDARY_END__`
+//! symbols marking its start and end. e.g.
+//!
+//! ```ld
+//! .percore_secondary (NOLOAD) : ALIGN(CACHE_LINE_SIZE) {
+//!     __PERCORE_SECONDARY_START__ = .;
+//!     . += (__PERCORE_END__ - __PERCORE_START__) * (CORE_COUNT - 1);
+//!     __PERCORE_SECONDARY_END__ = .;
+//! } >image
+//! ```
+//!
+//! Note that the `.percore_secondary` section is only used for secondary cores; the `.percore`
+//! section itself is used for the primary core's copy of the variables in this case.
+
 use super::{__PERCORE_END__, __PERCORE_START__};
 use core::arch::naked_asm;
 
@@ -17,15 +35,19 @@ unsafe extern "Rust" {
 /// area. The function is safe to be called from assembly without a stack present. It clobbers
 /// registers X0-X6.
 ///
-/// The function calculates the size of the percore section as the difference between the
-/// __PERCORE_START__ and __PERCORE_END__ symbols. Then it copies this memory area between the
-/// __PERCORE_SECONDARY_START__ and __PERCORE_SECONDARY_END__ symbols as many times as it fits.
+/// The function calculates the size of the `.percore` section as the difference between the
+/// `__PERCORE_START__` and `__PERCORE_END__` symbols. Then it copies this memory area between the
+/// `__PERCORE_SECONDARY_START__` and `__PERCORE_SECONDARY_END__` symbols as many times as it fits.
 /// The copy is done in 16 byte chunks, so these symbols must be aligned to at least a 16 byte
 /// boundary. The function is suitable for tiny and small memory models.
 ///
 /// # Safety
 ///
 /// This must only be called before any core accesses any percore variable.
+///
+/// You must ensure that this initialisation happens-before any percore variables are accessed
+/// (according to Rust's memory model). This could be achieved by calling it from assembly before
+/// caches are enabled or any Rust code runs.
 #[unsafe(naked)]
 pub unsafe extern "C" fn percore_copy_secondary_data() {
     naked_asm!(

--- a/src/derive/aarch64.rs
+++ b/src/derive/aarch64.rs
@@ -2,10 +2,16 @@
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
-use super::{
-    __PERCORE_END__, __PERCORE_SECONDARY_END__, __PERCORE_SECONDARY_START__, __PERCORE_START__,
-};
+use super::{__PERCORE_END__, __PERCORE_START__};
 use core::arch::naked_asm;
+
+#[allow(improper_ctypes)]
+unsafe extern "Rust" {
+    /// Symbol marking the start of the `.percore_secondary` section.
+    pub safe static __PERCORE_SECONDARY_START__: ();
+    /// Symbol marking the end of the `.percore_secondary` section.
+    pub safe static __PERCORE_SECONDARY_END__: ();
+}
 
 /// Duplicates the contents of the initialised percore section into the secondary cores' percore
 /// area. The function is safe to be called from assembly without a stack present. It clobbers

--- a/src/derive/aarch64.rs
+++ b/src/derive/aarch64.rs
@@ -16,8 +16,12 @@ use core::arch::naked_asm;
 /// __PERCORE_SECONDARY_START__ and __PERCORE_SECONDARY_END__ symbols as many times as it fits.
 /// The copy is done in 16 byte chunks, so these symbols must be aligned to at least a 16 byte
 /// boundary. The function is suitable for tiny and small memory models.
+///
+/// # Safety
+///
+/// This must only be called before any core accesses any percore variable.
 #[unsafe(naked)]
-pub extern "C" fn percore_copy_secondary_data() {
+pub unsafe extern "C" fn percore_copy_secondary_data() {
     naked_asm!(
         "bti	c
         adrp	x0, {PERCORE_START}

--- a/src/derive/aarch64.rs
+++ b/src/derive/aarch64.rs
@@ -80,7 +80,7 @@ pub extern "C" fn percore_copy_secondary_data() {
 /// to be called from assembly without a stack present. It clobbers registers X0-X2 and returns the
 /// offset in X0. The function is suitable for tiny and small memory models.
 #[unsafe(naked)]
-pub extern "C" fn percore_calculate_local_offset(core_index: usize) -> usize {
+pub extern "C" fn percore_calculate_local_offset(core_index: usize) -> isize {
     naked_asm!(
         "bti	c
         adrp	x1, {PERCORE_START}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::undocumented_unsafe_blocks)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,6 @@ pub mod derive;
 #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
 pub use self::exceptions::exception_free;
 pub use self::{exceptions::ExceptionFree, lock::ExceptionLock};
-
-#[cfg(feature = "derive")]
-pub use percore_derive::percore;
-
 use core::marker::PhantomData;
 
 /// Trait abstracting how to get the index of the current CPU core.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub use self::exceptions::exception_free;
 pub use self::{exceptions::ExceptionFree, lock::ExceptionLock};
 
 #[cfg(feature = "derive")]
-pub use percore_derive::{percore, percore_local_offset};
+pub use percore_derive::percore;
 
 use core::marker::PhantomData;
 


### PR DESCRIPTION
* Change the return type of `percore_local_offset` to `isize`, as implementations may want to place a core's copy of percore variables before the `.percore` section.
* Fix some safety issues, and adds more safety documentation.
* Add more documentation and examples.
* Make `percore_local_offset` a declarative macro rather than a derive macro, to be more flexible and allow types from other crates to be specified as the desired implementation.
* Added Rust implementation of `percore_copy_secondary_data` for other architectures.
* Other minor fixes.