### PR TITLE
Add unit tests for multiple cores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,18 @@
 
 ### Bugfixes
 
-- Don't allow unsafe code in initialisation expression of `#[percore]` variables.
 - Fixed undefined behaviour in `LinkedPerCore::get` due to pointer provenance.
+
+### Breaking changes
+
+- Don't allow unsafe code in initialisation expression of `#[percore]` variables.
+- Renamed `__PERCORE_START__`, `__PERCORE_END`, `__PERCORE_SECONDARD_START__` and
+  `__PERCORE_SECONDARY_END` static variables to `START_PERCORE`, `STOP_PERCORE`,
+  `START_PERCORE_SECONDARY` and `STOP_PERCORE_SECONDARY`. Renamed the corresponding symbols to
+  `__start_percore`, `__stop_percore` and so on on most platforms.
+- Renamed the `.percore` linker section to `percore`, and `.percore_secondary` to
+  `percore_secondary`. This lets the linker automatically generate the start and stop symbols as
+  above.
 
 ## 0.2.5
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ It requires the following actions from the consuming project:
 - Implement `percore::derive::PercoreLocalOffset` for a type that retrieves the previously stored
   offset and mark the type with `#[percore::percore_local_offset]`.
 - Allocate `.percore` and `.percore_secondary` sections in the linker script and mark their
-  boundaries using the `__PERCORE_START__`, `__PERCORE_END__`, `__PERCORE_SECONDARY_START__` and
-  `__PERCORE_SECONDARY_END__` symbols. It is recommended to align these sections to the cache line
+  boundaries using the `__start_percore`, `__stop_percore`, `__start_percore_secondary` and
+  `__stop_percore_secondary` symbols. It is recommended to align these sections to the cache line
   size but at least to 16 bytes on `AArch64`.
 
 ### Example
@@ -161,7 +161,7 @@ sized area for every secondary core in `.percore_secondary`.
 
 ```
 .percore : ALIGN(CACHE_LINE_SIZE) {
-    __PERCORE_START__ = .;
+    __start_percore = .;
     *(SORT_BY_ALIGNMENT(.percore .percore.*))
     /*
      * Round the section size up to the actual alignment of the section. This ensures that we can
@@ -169,13 +169,13 @@ sized area for every secondary core in `.percore_secondary`.
      * section.
      */
     . = ALIGN(ALIGNOF(.percore));
-    __PERCORE_END__ = .;
+    __stop_percore = .;
 } >image
 
 .percore_secondary (NOLOAD) : ALIGN(ALIGNOF(.percore)) {
-    __PERCORE_SECONDARY_START__ = .;
-    . += (__PERCORE_END__ - __PERCORE_START__) * (CORE_COUNT - 1);
-    __PERCORE_SECONDARY_END__ = .;
+    __start_percore_secondary = .;
+    . += (__stop_percore - __start_percore) * (CORE_COUNT - 1);
+    __stop_percore_secondary = .;
 } >image
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ Patches are welcome to add support for other architectures.
 ## Derive
 
 The `derive` feature enables the use of the `#[percore::percore]` attribute, which replaces a static
-with a `LinkedPerCore` of the same name in the `.percore` linker section. The wrapper stores the
+with a `LinkedPerCore` of the same name in the `percore` linker section. The wrapper stores the
 primary core's value and accesses the corresponding copy for the current core. This is an
 alternative to declaring per-core variables with `PerCore`.
 
 By default, the primary core is assumed to have index 0, with the secondary cores following it
 sequentially. Each core has its own per-core area, and these areas are laid out contiguously in
-memory, like an array of sections. Only the primary core's area, represented by the `.percore`
+memory, like an array of sections. Only the primary core's area, represented by the `percore`
 section is included in the image, and it contains the initial values for per-core variables. The
-corresponding areas for the secondary cores, represented by the `.percore_secondary` section, are
+corresponding areas for the secondary cores, represented by the `percore_secondary` section, are
 not included in the image. The provided functions are suitable for tiny and small memory models.
 
 Projects may use a different memory layout, provided that they copy the initial variable values into
@@ -101,7 +101,7 @@ It requires the following actions from the consuming project:
 - Store this offset in a project specific way.
 - Implement `percore::derive::PercoreLocalOffset` for a type that retrieves the previously stored
   offset and mark the type with `#[percore::percore_local_offset]`.
-- Allocate `.percore` and `.percore_secondary` sections in the linker script and mark their
+- Allocate `percore` and `percore_secondary` sections in the linker script and mark their
   boundaries using the `__start_percore`, `__stop_percore`, `__start_percore_secondary` and
   `__stop_percore_secondary` symbols. It is recommended to align these sections to the cache line
   size but at least to 16 bytes on `AArch64`.
@@ -156,26 +156,23 @@ unsafe impl PercoreLocalOffset for PercoreLocalOffsetImpl {
 
 #### Linker script
 
-The linker script places the primary core's initialized data in `.percore` and reserves an equally
-sized area for every secondary core in `.percore_secondary`.
+The linker script places the primary core's initialized data in `percore` and reserves an equally
+sized area for every secondary core in `percore_secondary`. The linker will automatically generate
+`__start_percore`, `__stop_percore`, `__start_percore_secondary` and `__stop_percore_secondary`
+symbols for these sections.
 
 ```
-.percore : ALIGN(CACHE_LINE_SIZE) {
-    __start_percore = .;
-    *(SORT_BY_ALIGNMENT(.percore .percore.*))
+percore : ALIGN(CACHE_LINE_SIZE) {
+    *(SORT_BY_ALIGNMENT(percore percore.*))
     /*
      * Round the section size up to the actual alignment of the section. This ensures that we can
-     * have an array of aligned copies of the .percore section inside the .percore_secondary
-     * section.
+     * have an array of aligned copies of the percore section inside the percore_secondary section.
      */
-    . = ALIGN(ALIGNOF(.percore));
-    __stop_percore = .;
+    . = ALIGN(ALIGNOF(percore));
 } >image
 
-.percore_secondary (NOLOAD) : ALIGN(ALIGNOF(.percore)) {
-    __start_percore_secondary = .;
+percore_secondary (NOLOAD) : ALIGN(ALIGNOF(percore)) {
     . += (__stop_percore - __start_percore) * (CORE_COUNT - 1);
-    __stop_percore_secondary = .;
 } >image
 ```
 

--- a/examples/aarch64_qemu/qemu.ld
+++ b/examples/aarch64_qemu/qemu.ld
@@ -15,7 +15,7 @@ CORE_COUNT = 2;
 SECTIONS
 {
 	.percore : ALIGN(16) {
-		__PERCORE_START__ = .;
+		__start_percore = .;
 		*(SORT_BY_ALIGNMENT(.percore .percore.*))
 		/*
 		 * Round the section size up to the actual alignment of the section. This ensures that we can
@@ -23,12 +23,12 @@ SECTIONS
 		 * section.
 		 */
 		. = ALIGN(ALIGNOF(.percore));
-		__PERCORE_END__ = .;
+		__stop_percore = .;
 	} >image
 
 	.percore_secondary (NOLOAD) : ALIGN(ALIGNOF(.percore)) {
-		__PERCORE_SECONDARY_START__ = .;
-		. += (__PERCORE_END__ - __PERCORE_START__) * (CORE_COUNT - 1);
-		__PERCORE_SECONDARY_END__ = .;
+		__start_percore_secondary = .;
+		. += (__stop_percore - __start_percore) * (CORE_COUNT - 1);
+		__stop_percore_secondary = .;
 	} >image
 }

--- a/examples/aarch64_qemu/qemu.ld
+++ b/examples/aarch64_qemu/qemu.ld
@@ -14,21 +14,16 @@ CORE_COUNT = 2;
 
 SECTIONS
 {
-	.percore : ALIGN(16) {
-		__start_percore = .;
-		*(SORT_BY_ALIGNMENT(.percore .percore.*))
+	percore : ALIGN(16) {
+		*(SORT_BY_ALIGNMENT(percore percore.*))
 		/*
 		 * Round the section size up to the actual alignment of the section. This ensures that we can
-		 * have an array of aligned copies of the .percore section inside the .percore_secondary
-		 * section.
+		 * have an array of aligned copies of the percore section inside the percore_secondary section.
 		 */
-		. = ALIGN(ALIGNOF(.percore));
-		__stop_percore = .;
+		. = ALIGN(ALIGNOF(percore));
 	} >image
 
-	.percore_secondary (NOLOAD) : ALIGN(ALIGNOF(.percore)) {
-		__start_percore_secondary = .;
+	percore_secondary (NOLOAD) : ALIGN(ALIGNOF(percore)) {
 		. += (__stop_percore - __start_percore) * (CORE_COUNT - 1);
-		__stop_percore_secondary = .;
 	} >image
 }

--- a/percore-derive/src/lib.rs
+++ b/percore-derive/src/lib.rs
@@ -32,7 +32,8 @@ pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let expr = &static_item.expr;
 
     quote! {
-        #[cfg_attr(target_os = "none", unsafe(link_section = "percore"))]
+        #[cfg_attr(any(target_os = "none", target_os = "linux", target_os = "android", target_os = "fuchsia", target_os = "psp", target_os = "freebsd", target_os = "openbsd"), unsafe(link_section = "percore"))]
+        #[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"), unsafe(link_section = "__DATA,__percore"))]
         #(#attrs)*
         #vis static #name: percore::derive::LinkedPerCore<#ty> = const {
             let value = #expr;

--- a/percore-derive/src/lib.rs
+++ b/percore-derive/src/lib.rs
@@ -9,7 +9,7 @@ use syn::{ItemStatic, parse_macro_input};
 /// Marks the variable as percore, creating an instance for each core.
 ///
 /// This replaces the static with a `percore::derive::LinkedPerCore` of the same name and places it
-/// in the `.percore` linker section. The static's symbol is the base address of the per-core variable
+/// in the `percore` linker section. The static's symbol is the base address of the per-core variable
 /// and can be used to access it from assembly.
 ///
 /// # Example
@@ -32,7 +32,7 @@ pub fn percore(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let expr = &static_item.expr;
 
     quote! {
-        #[cfg_attr(target_os = "none", unsafe(link_section = ".percore"))]
+        #[cfg_attr(target_os = "none", unsafe(link_section = "percore"))]
         #(#attrs)*
         #vis static #name: percore::derive::LinkedPerCore<#ty> = const {
             let value = #expr;

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -50,6 +50,8 @@ mod tests {
     fn percore_boxed_slice() {
         static STATE: Once<PerCore<BoxedSlice, FakeCoresImpl>> = Once::new();
 
+        FakeCoresImpl::set_core_index(0);
+
         STATE.call_once(|| {
             let boxed_slice: BoxedSlice = repeat_with(|| ExceptionLock::new(RefCell::new(42)))
                 .take(4)
@@ -71,6 +73,8 @@ mod tests {
     fn percore_boxed_slice_default() {
         static STATE: LazyLock<PerCore<BoxedSlice, FakeCoresImpl>> =
             LazyLock::new(|| PerCore::new_with_default(4));
+
+        FakeCoresImpl::set_core_index(0);
 
         {
             // SAFETY: There are no exceptions in the simulated environment of the tests.

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -59,6 +59,7 @@ mod tests {
         });
 
         {
+            // SAFETY: There are no exceptions in the simulated environment of the tests.
             let token = unsafe { ExceptionFree::new() };
             assert_eq!(*STATE.get().unwrap().get().borrow_mut(token), 42);
             *STATE.get().unwrap().get().borrow_mut(token) += 1;
@@ -72,6 +73,7 @@ mod tests {
             LazyLock::new(|| PerCore::new_with_default(4));
 
         {
+            // SAFETY: There are no exceptions in the simulated environment of the tests.
             let token = unsafe { ExceptionFree::new() };
             assert_eq!(*STATE.get().borrow_mut(token), 0);
             *STATE.get().borrow_mut(token) += 1;

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -4,26 +4,26 @@
 
 //! Linker section based per-core variables
 //!
-//! The `percore` attribute places a variable's initial value in the `.percore` linker section and
+//! The `percore` attribute places a variable's initial value in the `percore` linker section and
 //! exposes a `LinkedPerCore` wrapper that accesses the copy for the local CPU. The consuming
 //! project must initialize each CPU's percore area and provide its offset by implementing
 //! `PercoreLocalOffset` on a type marked with `percore_local_offset`.
 //!
 //! # Linker script
 //!
-//! You must include the `.percore` section in your linker script, with `__start_percore` and
+//! You must include the `percore` section in your linker script, with `__start_percore` and
 //! `__stop_percore` symbols to mark its boundaries. E.g.:
 //!
 //! ```ld
-//! .percore : ALIGN(CACHE_LINE_SIZE) {
+//! percore : ALIGN(CACHE_LINE_SIZE) {
 //!     __start_percore = .;
-//!     *(SORT_BY_ALIGNMENT(.percore .percore.*))
+//!     *(SORT_BY_ALIGNMENT(percore percore.*))
 //!     /*
 //!      * Round the section size up to the actual alignment of the section. This ensures that we
-//!      * can have an array of aligned copies of the .percore section inside the .percore_secondary
+//!      * can have an array of aligned copies of the percore section inside the percore_secondary
 //!      * section.
 //!      */
-//!     . = ALIGN(ALIGNOF(.percore));
+//!     . = ALIGN(ALIGNOF(percore));
 //!     __stop_percore = .;
 //! } >image
 //! ```
@@ -32,22 +32,22 @@
 //!
 //! Three possible ways to allocate and initialise each CPU's percore area are:
 //!
-//! 1. If you know the number of cores at build time, allocate a `.percore_secondary` section for it
+//! 1. If you know the number of cores at build time, allocate a `percore_secondary` section for it
 //!    in your linker script, and provide the `__start_percore_secondary` and
-//!    `__stop_percore_secondary` symbols. Copy the appropriate number of copies of the `.percore`
+//!    `__stop_percore_secondary` symbols. Copy the appropriate number of copies of the `percore`
 //!    section to this section in assembly code before any Rust code runs. On AArch64 bare-metal
 //!    targets [`aarch64::percore_copy_secondary_data`] is provided to implement this, and
 //!    [`aarch64::percore_calculate_local_offset`] to calculate the area's offset from a CPU linear
 //!    index. This must either be done before caches are enabled or with appropriate cache
 //!    maintenance operations to ensure that it is visible to all cores.
 //! 2. In your Rust entry point before any access to percore variables, copy the appropriate number
-//!    of copies of the `.percore` section to an appropriately sized area of memory.
+//!    of copies of the `percore` section to an appropriately sized area of memory.
 //!    [`percore_copy_secondary_data`] is provided to implement this. In this case you must use Rust
 //!    synchronisation primitives (e.g. an AtomicBool) to ensure that this happens-before any access
 //!    to percore variables.
-//! 3. Have each core initialise its own copy of the `.percore` section the first time it starts. In
+//! 3. Have each core initialise its own copy of the `percore` section the first time it starts. In
 //!    this case there is no distinction between primary and secondary cores, and the original
-//!    `.percore` section must never be modified (or at least not until all cores have started and
+//!    `percore` section must never be modified (or at least not until all cores have started and
 //!    initialised their copies). `percore_copy_secondary_data` can also be used for this.
 //!
 //! In any case, you must ensure that the alignment of each CPU's percore area is greater than or
@@ -83,15 +83,15 @@ pub use percore_derive::percore;
 
 #[allow(improper_ctypes)]
 unsafe extern "Rust" {
-    /// Symbol marking the start of the `.percore` section.
+    /// Symbol marking the start of the `percore` section.
     #[link_name = "__start_percore"]
     pub safe static START_PERCORE: ();
-    /// Symbol marking the end of the `.percore` section.
+    /// Symbol marking the end of the `percore` section.
     #[link_name = "__stop_percore"]
     pub safe static STOP_PERCORE: ();
 }
 
-/// Returns the size in bytes of a single core's `.percore` section.
+/// Returns the size in bytes of a single core's `percore` section.
 pub fn percore_size() -> usize {
     &raw const STOP_PERCORE as usize - &raw const START_PERCORE as usize
 }
@@ -99,11 +99,11 @@ pub fn percore_size() -> usize {
 /// Duplicates the contents of the initialised percore section into the secondary cores' percore
 /// area.
 ///
-/// The function calculates the size of the `.percore` section as the difference between the
+/// The function calculates the size of the `percore` section as the difference between the
 /// `__start_percore` and `__stop_percore` symbols. Then it copies this memory area into the
 /// given `secondary_percore_area` as many times as it fits.
 ///
-/// Panics if the length of `secondary_percore_area` isn't a multiple of the size of the `.percore`
+/// Panics if the length of `secondary_percore_area` isn't a multiple of the size of the `percore`
 /// section.
 ///
 /// This also exposes the provenance of the `secondary_percore_area`, as `LinkedPerCore::get` will
@@ -113,7 +113,7 @@ pub fn percore_size() -> usize {
 ///
 /// This must only be called before any core accesses any percore variable.
 ///
-/// `secondary_percore_area` must be valid for writes, and must not overlap with the `.percore
+/// `secondary_percore_area` must be valid for writes, and must not overlap with the `percore
 /// section.
 ///
 /// You must ensure that this initialisation happens-before any percore variables are accessed
@@ -130,7 +130,7 @@ pub unsafe fn percore_copy_secondary_data(secondary_percore_area: *mut [u8]) {
     for i in 0..copies {
         let dest = (secondary_percore_area as *mut u8).wrapping_byte_add(i * percore_size);
         // SAFETY: The caller promises that `secondary_percore_area` is valid to write and doesn't
-        // overlap with the `.percore` section.
+        // overlap with the `percore` section.
         unsafe {
             percore_start.copy_to_nonoverlapping(dest, percore_size);
         }
@@ -151,7 +151,7 @@ pub unsafe fn percore_copy_secondary_data(secondary_percore_area: *mut [u8]) {
 /// The offset must point to a valid and initialized percore memory area and it must not
 /// overflow `isize` for any percore variable and core.
 pub unsafe trait PercoreLocalOffset {
-    /// Returns the byte offset of the local core's percore area from the `.percore` section.
+    /// Returns the byte offset of the local core's percore area from the `percore` section.
     fn percore_local_offset() -> isize;
 }
 
@@ -181,7 +181,7 @@ impl<T> LinkedPerCore<T> {
     ///
     /// # Safety
     ///
-    /// The created variable must be a static placed in the `.percore` section and the project must
+    /// The created variable must be a static placed in the `percore` section and the project must
     /// have a valid `PercoreLocalOffset` implementation. It must only be accessed after
     /// `percore_copy_secondary_data` has run.
     pub const unsafe fn new(value: T) -> Self {

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -288,30 +288,55 @@ mod tests {
     use super::*;
     use crate as percore;
     use crate::ExceptionFree;
-    use core::{cell::RefCell, num::NonZero};
+    use core::{cell::RefCell, num::NonZero, ptr::NonNull};
+    use std::{thread, thread_local};
 
-    #[percore]
-    static VALUE: ExceptionLock<RefCell<u64>> =
-        ExceptionLock::new(RefCell::new(0xabcd_ef01_2345_6789));
+    // We simulate cores with threads for unit tests, so we use a thread-local for the percore
+    // region of each thread.
+    thread_local! {
+        static PERCORE_REGION: RefCell<Option<NonNull<[u8]>>> = RefCell::new(None);
+    }
 
     percore_local_offset!(PercoreLocalOffsetImpl);
     struct PercoreLocalOffsetImpl;
 
-    // SAFETY: Tests use the initialized primary-core value at offset zero.
+    // SAFETY: The offset returned always points to a region allocated for the core, initialised
+    // with a copy of the percore section.
     unsafe impl PercoreLocalOffset for PercoreLocalOffsetImpl {
         fn percore_local_offset() -> isize {
-            0
+            PERCORE_REGION.with_borrow_mut(|region| {
+                let region = region.get_or_insert_with(|| {
+                    let new_region = Box::into_raw(vec![0; percore_size()].into_boxed_slice());
+                    // SAFETY: new_region is valid for writes because we just allocated it, and no
+                    // percore variables have been accessed on this core yet because this is the
+                    // first time percore_local_offset has been called.
+                    unsafe {
+                        percore_copy_secondary_data(new_region);
+                    }
+                    NonNull::new(new_region).unwrap()
+                });
+                // Calculate offset.
+                isize::try_from(region.addr().get())
+                    .unwrap()
+                    .checked_sub((&raw const START_PERCORE).addr().try_into().unwrap())
+                    .unwrap()
+            })
         }
     }
 
     #[test]
     fn test_percore_derive() {
+        #[percore]
+        static VALUE: ExceptionLock<RefCell<u64>> =
+            ExceptionLock::new(RefCell::new(0xabcd_ef01_2345_6789));
+
+        // SAFETY: There are no exceptions in the simulated environment of the tests.
         let token = unsafe { ExceptionFree::new() };
 
-        assert_eq!(0xabcd_ef01_2345_6789, *VALUE.get().borrow(token).borrow());
+        assert_eq!(*VALUE.get().borrow(token).borrow(), 0xabcd_ef01_2345_6789);
 
         *VALUE.get().borrow_mut(token) = 10;
-        assert_eq!(10, *VALUE.get().borrow(token).borrow());
+        assert_eq!(*VALUE.get().borrow(token).borrow(), 10);
     }
 
     #[test]
@@ -319,5 +344,31 @@ mod tests {
         #[percore]
         static VALUE: ExceptionLock<NonZero<u64>> =
             ExceptionLock::new(unsafe { NonZero::new_unchecked(42) });
+    }
+
+    #[test]
+    fn multiple_cores() {
+        // SAFETY: There are no exceptions in the simulated environment of the tests.
+        let token = unsafe { ExceptionFree::new() };
+
+        #[percore]
+        static VALUE: ExceptionLock<RefCell<u64>> = ExceptionLock::new(RefCell::new(42));
+
+        assert_eq!(*VALUE.get().borrow_mut(token), 42);
+        *VALUE.get().borrow_mut(token) = 1;
+        assert_eq!(*VALUE.get().borrow_mut(token), 1);
+
+        thread::spawn(|| {
+            // SAFETY: There are no exceptions in the simulated environment of the tests.
+            let token = unsafe { ExceptionFree::new() };
+
+            assert_eq!(*VALUE.get().borrow_mut(token), 42);
+            *VALUE.get().borrow_mut(token) = 2;
+            assert_eq!(*VALUE.get().borrow_mut(token), 2);
+        })
+        .join()
+        .unwrap();
+
+        assert_eq!(*VALUE.get().borrow_mut(token), 1);
     }
 }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -84,10 +84,40 @@ pub use percore_derive::percore;
 #[allow(improper_ctypes)]
 unsafe extern "Rust" {
     /// Symbol marking the start of the `percore` section.
-    #[link_name = "__start_percore"]
+    #[cfg_attr(
+        any(
+            target_os = "none",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "psp",
+            target_os = "freebsd",
+            target_os = "openbsd",
+        ),
+        link_name = "__start_percore"
+    )]
+    #[cfg_attr(
+        any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+        link_name = "\x01section$start$__DATA$__percore"
+    )]
     pub safe static START_PERCORE: ();
     /// Symbol marking the end of the `percore` section.
-    #[link_name = "__stop_percore"]
+    #[cfg_attr(
+        any(
+            target_os = "none",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "psp",
+            target_os = "freebsd",
+            target_os = "openbsd",
+        ),
+        link_name = "__stop_percore"
+    )]
+    #[cfg_attr(
+        any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+        link_name = "\x01section$end$__DATA$__percore"
+    )]
     pub safe static STOP_PERCORE: ();
 }
 

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -154,6 +154,10 @@ pub unsafe fn percore_copy_secondary_data(secondary_percore_area: *mut [u8]) {
     let percore_start = (&raw const START_PERCORE).cast::<u8>();
     let percore_size = percore_size();
 
+    if percore_size == 0 {
+        return;
+    }
+
     assert!(secondary_percore_area.len().is_multiple_of(percore_size));
     let copies = secondary_percore_area.len() / percore_size;
 

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -11,12 +11,12 @@
 //!
 //! # Linker script
 //!
-//! You must include the `.percore` section in your linker script, with `__PERCORE_START__` and
-//! `__PERCORE_END__` symbols to mark its boundaries. E.g.:
+//! You must include the `.percore` section in your linker script, with `__start_percore` and
+//! `__stop_percore` symbols to mark its boundaries. E.g.:
 //!
 //! ```ld
 //! .percore : ALIGN(CACHE_LINE_SIZE) {
-//!     __PERCORE_START__ = .;
+//!     __start_percore = .;
 //!     *(SORT_BY_ALIGNMENT(.percore .percore.*))
 //!     /*
 //!      * Round the section size up to the actual alignment of the section. This ensures that we
@@ -24,7 +24,7 @@
 //!      * section.
 //!      */
 //!     . = ALIGN(ALIGNOF(.percore));
-//!     __PERCORE_END__ = .;
+//!     __stop_percore = .;
 //! } >image
 //! ```
 //!
@@ -33,8 +33,8 @@
 //! Three possible ways to allocate and initialise each CPU's percore area are:
 //!
 //! 1. If you know the number of cores at build time, allocate a `.percore_secondary` section for it
-//!    in your linker script, and provide the `__PERCORE_SECONDARY_START__` and
-//!    `__PERCORE_SECONDARY_END__` symbols. Copy the appropriate number of copies of the `.percore`
+//!    in your linker script, and provide the `__start_percore_secondary` and
+//!    `__stop_percore_secondary` symbols. Copy the appropriate number of copies of the `.percore`
 //!    section to this section in assembly code before any Rust code runs. On AArch64 bare-metal
 //!    targets [`aarch64::percore_copy_secondary_data`] is provided to implement this, and
 //!    [`aarch64::percore_calculate_local_offset`] to calculate the area's offset from a CPU linear
@@ -84,21 +84,23 @@ pub use percore_derive::percore;
 #[allow(improper_ctypes)]
 unsafe extern "Rust" {
     /// Symbol marking the start of the `.percore` section.
-    pub safe static __PERCORE_START__: ();
+    #[link_name = "__start_percore"]
+    pub safe static START_PERCORE: ();
     /// Symbol marking the end of the `.percore` section.
-    pub safe static __PERCORE_END__: ();
+    #[link_name = "__stop_percore"]
+    pub safe static STOP_PERCORE: ();
 }
 
 /// Returns the size in bytes of a single core's `.percore` section.
 pub fn percore_size() -> usize {
-    &raw const __PERCORE_END__ as usize - &raw const __PERCORE_START__ as usize
+    &raw const STOP_PERCORE as usize - &raw const START_PERCORE as usize
 }
 
 /// Duplicates the contents of the initialised percore section into the secondary cores' percore
 /// area.
 ///
 /// The function calculates the size of the `.percore` section as the difference between the
-/// `__PERCORE_START__` and `__PERCORE_END__` symbols. Then it copies this memory area into the
+/// `__start_percore` and `__stop_percore` symbols. Then it copies this memory area into the
 /// given `secondary_percore_area` as many times as it fits.
 ///
 /// Panics if the length of `secondary_percore_area` isn't a multiple of the size of the `.percore`
@@ -119,7 +121,7 @@ pub fn percore_size() -> usize {
 /// AtomicBool with release semantics and having other cores wait until they see the written value
 /// with acquire semantics.
 pub unsafe fn percore_copy_secondary_data(secondary_percore_area: *mut [u8]) {
-    let percore_start = (&raw const __PERCORE_START__).cast::<u8>();
+    let percore_start = (&raw const START_PERCORE).cast::<u8>();
     let percore_size = percore_size();
 
     assert!(secondary_percore_area.len().is_multiple_of(percore_size));

--- a/src/derive/aarch64.rs
+++ b/src/derive/aarch64.rs
@@ -6,29 +6,31 @@
 //! targets where the number of cores is known at build time.
 //!
 //! These assume that your linker script has a `.percore_secondary` section located immediately
-//! after the `.percore` section, with `__PERCORE_SECONDARY_START__` and `__PERCORE_SECONDARY_END__`
+//! after the `.percore` section, with `__start_percore_secondary` and `__stop_percore_secondary`
 //! symbols marking its start and end. e.g.
 //!
 //! ```ld
 //! .percore_secondary (NOLOAD) : ALIGN(ALIGNOF(.percore)) {
-//!     __PERCORE_SECONDARY_START__ = .;
-//!     . += (__PERCORE_END__ - __PERCORE_START__) * (CORE_COUNT - 1);
-//!     __PERCORE_SECONDARY_END__ = .;
+//!     __start_percore_secondary = .;
+//!     . += (__start_percore - __stop_percore) * (CORE_COUNT - 1);
+//!     __stop_percore_secondary = .;
 //! } >image
 //! ```
 //!
 //! Note that the `.percore_secondary` section is only used for secondary cores; the `.percore`
 //! section itself is used for the primary core's copy of the variables in this case.
 
-use super::{__PERCORE_END__, __PERCORE_START__};
+use super::{START_PERCORE, STOP_PERCORE};
 use core::arch::naked_asm;
 
 #[allow(improper_ctypes)]
 unsafe extern "Rust" {
     /// Symbol marking the start of the `.percore_secondary` section.
-    pub safe static __PERCORE_SECONDARY_START__: ();
+    #[link_name = "__start_percore_secondary"]
+    pub safe static START_PERCORE_SECONDARY: ();
     /// Symbol marking the end of the `.percore_secondary` section.
-    pub safe static __PERCORE_SECONDARY_END__: ();
+    #[link_name = "__stop_percore_secondary"]
+    pub safe static STOP_PERCORE_SECONDARY: ();
 }
 
 /// Duplicates the contents of the initialised percore section into the secondary cores' percore
@@ -36,8 +38,8 @@ unsafe extern "Rust" {
 /// registers X0-X6.
 ///
 /// The function calculates the size of the `.percore` section as the difference between the
-/// `__PERCORE_START__` and `__PERCORE_END__` symbols. Then it copies this memory area between the
-/// `__PERCORE_SECONDARY_START__` and `__PERCORE_SECONDARY_END__` symbols as many times as it fits.
+/// `__start_percore` and `__stop_percore` symbols. Then it copies this memory area between the
+/// `__start_percore_secondary` and `__stop_percore_secondary` symbols as many times as it fits.
 /// The copy is done in 16 byte chunks, so these symbols must be aligned to at least a 16 byte
 /// boundary. The function is suitable for tiny and small memory models.
 ///
@@ -52,14 +54,14 @@ unsafe extern "Rust" {
 pub unsafe extern "C" fn percore_copy_secondary_data() {
     naked_asm!(
         "bti	c
-        adrp	x0, {PERCORE_START}
-        add	x0, x0, :lo12:{PERCORE_START}
-        adrp	x1, {PERCORE_END}
-        add	x1, x1, :lo12:{PERCORE_END}
-        adrp	x2, {PERCORE_SECONDARY_START}
-        add	x2, x2, :lo12:{PERCORE_SECONDARY_START}
-        adrp	x3, {PERCORE_SECONDARY_END}
-        add	x3, x3, :lo12:{PERCORE_SECONDARY_END}
+        adrp	x0, {START_PERCORE}
+        add	x0, x0, :lo12:{START_PERCORE}
+        adrp	x1, {STOP_PERCORE}
+        add	x1, x1, :lo12:{STOP_PERCORE}
+        adrp	x2, {START_PERCORE_SECONDARY}
+        add	x2, x2, :lo12:{START_PERCORE_SECONDARY}
+        adrp	x3, {STOP_PERCORE_SECONDARY}
+        add	x3, x3, :lo12:{STOP_PERCORE_SECONDARY}
 
         /* Check whether the percore section is empty. */
         cmp	x0, x1
@@ -99,15 +101,15 @@ pub unsafe extern "C" fn percore_copy_secondary_data() {
 
     3:
         ret",
-        PERCORE_START = sym __PERCORE_START__,
-        PERCORE_END = sym __PERCORE_END__,
-        PERCORE_SECONDARY_START = sym __PERCORE_SECONDARY_START__,
-        PERCORE_SECONDARY_END = sym __PERCORE_SECONDARY_END__,
+        START_PERCORE = sym START_PERCORE,
+        STOP_PERCORE = sym STOP_PERCORE,
+        START_PERCORE_SECONDARY = sym START_PERCORE_SECONDARY,
+        STOP_PERCORE_SECONDARY = sym STOP_PERCORE_SECONDARY,
     )
 }
 
 /// Calculates the offset of the core's percore area from the percore sections beginning using the
-/// following formula: `(__PERCORE_END__ - __PERCORE_START__) * core_index`. The intended use of
+/// following formula: `(__stop_percore - __stop_percore) * core_index`. The intended use of
 /// this function is to use its output to set the offset register of the core. The function is safe
 /// to be called from assembly without a stack present. It clobbers registers X0-X2 and returns the
 /// offset in X0. The function is suitable for tiny and small memory models.
@@ -115,14 +117,14 @@ pub unsafe extern "C" fn percore_copy_secondary_data() {
 pub extern "C" fn percore_calculate_local_offset(core_index: usize) -> isize {
     naked_asm!(
         "bti	c
-        adrp	x1, {PERCORE_START}
-        add	x1, x1, :lo12:{PERCORE_START}
-        adrp	x2, {PERCORE_END}
-        add	x2, x2, :lo12:{PERCORE_END}
+        adrp	x1, {START_PERCORE}
+        add	x1, x1, :lo12:{START_PERCORE}
+        adrp	x2, {STOP_PERCORE}
+        add	x2, x2, :lo12:{STOP_PERCORE}
         sub	x1, x2, x1
         mul	x0, x0, x1
         ret",
-        PERCORE_START = sym __PERCORE_START__,
-        PERCORE_END = sym __PERCORE_END__,
+        START_PERCORE = sym START_PERCORE,
+        STOP_PERCORE = sym STOP_PERCORE,
     )
 }

--- a/src/derive/aarch64.rs
+++ b/src/derive/aarch64.rs
@@ -5,19 +5,19 @@
 //! Assembly implementations of percore initialisation helper functions for AArch64 bare-metal
 //! targets where the number of cores is known at build time.
 //!
-//! These assume that your linker script has a `.percore_secondary` section located immediately
-//! after the `.percore` section, with `__start_percore_secondary` and `__stop_percore_secondary`
+//! These assume that your linker script has a `percore_secondary` section located immediately
+//! after the `percore` section, with `__start_percore_secondary` and `__stop_percore_secondary`
 //! symbols marking its start and end. e.g.
 //!
 //! ```ld
-//! .percore_secondary (NOLOAD) : ALIGN(ALIGNOF(.percore)) {
+//! percore_secondary (NOLOAD) : ALIGN(ALIGNOF(percore)) {
 //!     __start_percore_secondary = .;
 //!     . += (__start_percore - __stop_percore) * (CORE_COUNT - 1);
 //!     __stop_percore_secondary = .;
 //! } >image
 //! ```
 //!
-//! Note that the `.percore_secondary` section is only used for secondary cores; the `.percore`
+//! Note that the `percore_secondary` section is only used for secondary cores; the `percore`
 //! section itself is used for the primary core's copy of the variables in this case.
 
 use super::{START_PERCORE, STOP_PERCORE};
@@ -25,10 +25,10 @@ use core::arch::naked_asm;
 
 #[allow(improper_ctypes)]
 unsafe extern "Rust" {
-    /// Symbol marking the start of the `.percore_secondary` section.
+    /// Symbol marking the start of the `percore_secondary` section.
     #[link_name = "__start_percore_secondary"]
     pub safe static START_PERCORE_SECONDARY: ();
-    /// Symbol marking the end of the `.percore_secondary` section.
+    /// Symbol marking the end of the `percore_secondary` section.
     #[link_name = "__stop_percore_secondary"]
     pub safe static STOP_PERCORE_SECONDARY: ();
 }
@@ -37,7 +37,7 @@ unsafe extern "Rust" {
 /// area. The function is safe to be called from assembly without a stack present. It clobbers
 /// registers X0-X6.
 ///
-/// The function calculates the size of the `.percore` section as the difference between the
+/// The function calculates the size of the `percore` section as the difference between the
 /// `__start_percore` and `__stop_percore` symbols. Then it copies this memory area between the
 /// `__start_percore_secondary` and `__stop_percore_secondary` symbols as many times as it fits.
 /// The copy is done in 16 byte chunks, so these symbols must be aligned to at least a 16 byte

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,14 +149,30 @@ unsafe impl<T: Send, C: Cores, const CORE_COUNT: usize> Sync
 mod tests {
     use super::*;
     use core::cell::RefCell;
+    use std::sync::Mutex;
 
-    /// A Fake implementation of `Cores` for test, that will always return 0.
+    /// Index of the current simulated core. Must be set to an actual number before accessing a
+    /// PerCore variable.
+    static CORE_INDEX: Mutex<Option<usize>> = Mutex::new(None);
+
+    /// A Fake implementation of `Cores` for tests, which will return the value set by
+    /// `set_core_index`.
     pub struct FakeCoresImpl;
+
+    impl FakeCoresImpl {
+        /// Sets the fake core index for this thread.
+        pub fn set_core_index(core_index: usize) {
+            *CORE_INDEX.lock().unwrap() = Some(core_index);
+        }
+    }
 
     // SAFETY: These tests are all run on a single core.
     unsafe impl Cores for FakeCoresImpl {
         fn core_index() -> usize {
-            0
+            CORE_INDEX
+                .lock()
+                .unwrap()
+                .expect("CORE_INDEX not set in test")
         }
     }
 
@@ -165,11 +181,30 @@ mod tests {
         static STATE: PerCore<[ExceptionLock<RefCell<u32>>; 4], FakeCoresImpl> =
             PerCore::new([const { ExceptionLock::new(RefCell::new(42)) }; 4]);
 
+        FakeCoresImpl::set_core_index(0);
         {
             // SAFETY: There are no exceptions in the simulated environment of the tests.
             let token = unsafe { ExceptionFree::new() };
             assert_eq!(*STATE.get().borrow_mut(token), 42);
             *STATE.get().borrow_mut(token) += 1;
+            assert_eq!(*STATE.get().borrow_mut(token), 43);
+        }
+
+        // A different core should see the original value.
+        FakeCoresImpl::set_core_index(1);
+        {
+            // SAFETY: There are no exceptions in the simulated environment of the tests.
+            let token = unsafe { ExceptionFree::new() };
+            assert_eq!(*STATE.get().borrow_mut(token), 42);
+            *STATE.get().borrow_mut(token) -= 2;
+            assert_eq!(*STATE.get().borrow_mut(token), 40);
+        }
+
+        // The first core should still see the value it set.
+        FakeCoresImpl::set_core_index(0);
+        {
+            // SAFETY: There are no exceptions in the simulated environment of the tests.
+            let token = unsafe { ExceptionFree::new() };
             assert_eq!(*STATE.get().borrow_mut(token), 43);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! }
 //! ```
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(clippy::undocumented_unsafe_blocks)]
 #![deny(unsafe_op_in_unsafe_fn)]
@@ -153,7 +153,7 @@ mod tests {
     /// A Fake implementation of `Cores` for test, that will always return 0.
     pub struct FakeCoresImpl;
 
-    // SAFETY: Tests are all run on a single core.
+    // SAFETY: These tests are all run on a single core.
     unsafe impl Cores for FakeCoresImpl {
         fn core_index() -> usize {
             0
@@ -166,6 +166,7 @@ mod tests {
             PerCore::new([const { ExceptionLock::new(RefCell::new(42)) }; 4]);
 
         {
+            // SAFETY: There are no exceptions in the simulated environment of the tests.
             let token = unsafe { ExceptionFree::new() };
             assert_eq!(*STATE.get().borrow_mut(token), 42);
             *STATE.get().borrow_mut(token) += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```no_run
 //! use core::cell::RefCell;
 //! # #[cfg(target_arch = "aarch64")]
 //! use percore::{exception_free, Cores, ExceptionLock, PerCore};


### PR DESCRIPTION
For the `#[percore]` macro approach we can simulate multiple cores with threads. To make this work I've renamed `.percore` to `percore` so that the linker will automatically generate `__start_percore` and `__stop_percore` symbols (on most platforms, MacOS has different names). I've also renamed `.percore_secondary` and its symbols similarly.